### PR TITLE
CI: Show details when running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,8 @@ language: haskell
 
 ghc:
   - 7.8
+
+script:
+  - cabal configure --enable-tests
+  - cabal build
+  - cabal test --show-details=always


### PR DESCRIPTION
This is important to be able to verify that the tests are indeed being
run as part of CI. If none of them are run and the output is hidden, we
might not notice at all.
