### PR TITLE
Add program to simulate at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Concepts
 
-[![Build Status](https://travis-ci.org/tuura/concepts.svg?branch=master)](https://travis-ci.org/tuura/concepts) [![Build status](https://ci.appveyor.com/api/projects/status/dn6igqdxf3cq2t8w/branch/master?svg=true)](https://ci.appveyor.com/project/snowleopard/concepts/branch/master)
+[![Build Status](https://travis-ci.org/tuura/concepts.svg?branch=master)](https://travis-ci.org/tuura/concepts)
+[![Build status](https://ci.appveyor.com/api/projects/status/dn6igqdxf3cq2t8w/branch/master?svg=true)](https://ci.appveyor.com/project/snowleopard/concepts/branch/master)
 
 A DSL for asynchronous circuits specification.
 

--- a/concepts.cabal
+++ b/concepts.cabal
@@ -29,6 +29,18 @@ library
     other-extensions: TypeFamilies
     GHC-options:      -Wall -fwarn-tabs
 
+executable simulate
+    hs-source-dirs:   simulate
+    main-is:          Main.hs
+    build-depends:    base >= 4.7 && < 5,
+                      text,
+                      directory,
+                      hint >= 0.5.1,
+                      concepts
+    default-language: Haskell2010
+    other-extensions: TypeFamilies
+    GHC-options:      -Wall -fwarn-tabs
+
 test-suite concepts-test
     type:             exitcode-stdio-1.0
     main-is:          Test.hs

--- a/examples/Concept.hs
+++ b/examples/Concept.hs
@@ -1,0 +1,10 @@
+module Concept where
+
+import Tuura.Concept
+
+-- Signals
+data Signal = A | B | C deriving (Eq, Show, Enum, Bounded)
+
+-- Example circuit described using gate-level concepts
+circuit :: (Eq a) => a -> a -> a -> CircuitConcept a
+circuit a b c = consistency <> cElement a b c <> inverter c a <> inverter c b

--- a/simulate/Main.hs
+++ b/simulate/Main.hs
@@ -1,0 +1,172 @@
+module Main (main) where
+
+import Data.Char
+import Data.List
+import qualified Data.Text as Text
+import System.Directory
+import Control.Exception
+import System.Environment
+import System.IO.Error
+
+import Tuura.Concept
+import Tuura.Concept.Simulation
+
+import qualified Language.Haskell.Interpreter as GHC
+import qualified Language.Haskell.Interpreter.Unsafe as GHC
+
+main :: IO ()
+main = do
+    args <- getArgs
+    if length args /= 1
+        then putStrLn "Exactly one path needed"
+        else do
+            r <- GHC.runInterpreter $ doWork (head args)
+            case r of
+               Left err -> putStrLn $ errorString err
+               Right () -> return ()
+
+{- Print a human-readable error string. -}
+errorString :: GHC.InterpreterError -> String
+errorString (GHC.WontCompile es) = intercalate "\n" (header : map unbox es)
+    where
+      header = "ERROR: Won't compile:"
+      unbox (GHC.GhcError e) = e
+errorString e = show e
+
+{- Our own Signal type. Contains the names of the possible signals in
+ - the user's module (constructor names) and its index, from 0 to x-1 if
+ - there are x signals. -}
+data DynSignal = Signal String Int deriving Eq
+
+instance Show DynSignal where show (Signal name _) = name
+
+{- Temporary module to help us use any number of signals in the user's
+ - circuit. Otherwise, we would be bound to a number of arguments
+ - (signals) known at compile time.
+ - Keep the DynSignal code in sync with above! -}
+signalsApply :: [String] -> [String]
+signalsApply names = [
+    "data DynSignal = Signal String Int deriving Eq",
+    "instance Show DynSignal where show (Signal name _) = name",
+    "names = " ++ show names,
+    "signs = [Signal (names !! i) i | i <- [0.." ++ show (num-1) ++ "]]",
+    "apply c = c " ++ unwords ["(signs !! " ++ show i ++ ")" | i <- [0..num-1]]]
+      where num = length names
+
+writeTmpFile :: [String] -> IO ()
+writeTmpFile ls =
+    writeFile tmpModuleFile $ unlines withModule
+      where withModule = ("module " ++ tmpModuleName ++ " where") : ls
+
+removeIfExists :: FilePath -> IO ()
+removeIfExists fileName = removeFile fileName `catch` handleExists
+  where handleExists e
+          | isDoesNotExistError e = return ()
+          | otherwise = throwIO e
+
+{- Exported names in the user's haskell module (file) -}
+moduleName :: String
+moduleName = "Concept"
+
+circuitName :: String
+circuitName = "circuit"
+
+tmpModuleName :: String
+tmpModuleName = "Helper"
+
+tmpModuleFile :: String
+tmpModuleFile = ".Helper.hs"
+
+{- Helper functions because we deal with String, not Text. -}
+
+count :: String -> String -> Int
+count sub str = Text.count (Text.pack sub) (Text.pack str)
+
+strRepeat :: Int -> String -> String
+strRepeat n str = Text.unpack $ Text.replicate n (Text.pack str)
+
+doWork :: String -> GHC.Interpreter ()
+doWork path = do
+    {- Load user's module to gather info. -}
+    GHC.loadModules [path]
+    GHC.setTopLevelModules [moduleName]
+    exports <- GHC.getModuleExports moduleName
+    let signalType = head $ filter (\x -> "Signal" == GHC.name x) exports
+    let names = GHC.children signalType
+    liftIO $ putStrLn $ "Signal names: " ++ show names
+    --
+    {- Use the circuit's type to gather how many signals it takes. -}
+    t <- GHC.typeOf circuitName
+    let numSigns = count "->" t
+    liftIO $ putStrLn $ "Circuit signals: " ++ show numSigns
+    {- Load the generated module too. -}
+    liftIO $ writeTmpFile $ signalsApply names
+    GHC.loadModules [path, tmpModuleFile]
+    liftIO $ removeIfExists tmpModuleFile
+    GHC.setTopLevelModules [moduleName, tmpModuleName]
+    {- Fetch our signals and initial state. -}
+    {- TODO: "a,b,c" will not always be "A,B,C" -}
+    signs <- GHC.interpret "signs" (GHC.as :: [DynSignal])
+    --
+    {- Obtain the circuit in terms of any signal (takes them as args). -}
+    let ctype = strRepeat numSigns "DynSignal ->" ++ "CircuitConcept DynSignal"
+    circuit <- GHC.unsafeInterpret circuitName ctype
+    {- Use our generated code to apply our signals to the circuit above -}
+    apply <- GHC.unsafeInterpret "apply" $ "(" ++ ctype ++ ") -> CircuitConcept DynSignal"
+    let fullCircuit = apply circuit
+    {- Run the interactive simulation. -}
+    initialState <- liftIO $ readState numSigns
+    liftIO $ putStrLn ""
+    (_, finalState) <- liftIO $ runSimulation (doSimulate signs fullCircuit) initialState
+    liftIO $ putStrLn $ "\nFinal state: " ++ showState finalState signs
+
+isBinary :: String -> Bool
+isBinary = foldr (\c -> (&&) (c == '0' || c == '1')) True
+
+readState :: Int -> IO (State DynSignal)
+readState num = do
+    putStr "Initial state: "
+    word <- getLine
+    if length word /= num || not (isBinary word)
+        then do
+            let start = replicate num '0'
+            let end = replicate num '1'
+            let ranging = "from " ++ start ++ " to " ++ end
+            putStrLn $ "Invalid state! Use a binary array ranging " ++ ranging
+            readState num
+        else return $ State (\(Signal _ i) -> '1' == word !! i)
+
+{- Helper functions to avoid needing SignalWrapper to be Enum/Bounded -}
+
+showState :: State t -> [t] -> String
+showState (State v) = map (\s -> if v s then '1' else '0')
+
+allTrans :: [a] -> [Transition a]
+allTrans signs = [Transition s b | s <- signs, b <- [False, True]]
+
+enabledTrans :: Monad m => s -> Concept s (Transition a) -> [a] -> m [Transition a]
+enabledTrans st c signs =
+    return $ filter (\t -> excited c t st) $ allTrans signs
+
+{- Find the signal with a matching name. -}
+readSignal :: [DynSignal] -> String -> DynSignal
+readSignal (s:ls) word = if show s == word then s else readSignal ls word
+readSignal [] _ = Signal "?" (-1)
+
+doSimulate :: MonadIO m => [DynSignal] -> Concept (State DynSignal) (Transition DynSignal) -> StateT (State DynSignal) m ()
+doSimulate signs circuit = do
+    st <- get
+    liftIO $ putStrLn $ "State: " ++ showState st signs
+    ts <- enabledTrans st circuit signs
+    liftIO $ putStrLn $ "Enabled: " ++ show ts
+    liftIO $ putStr "Do: "
+    word <- liftIO getLine
+    unless ("end" == map toLower word) $ do
+        let signWord = init word
+        let up = '+' == last word
+        let sign = readSignal signs signWord
+        let t = Transition sign up
+        if t `elem` ts
+            then fire t
+            else liftIO $ putStrLn "Invalid transition!"
+        doSimulate signs circuit


### PR DESCRIPTION
You'll need `hint` installed.

Usage:

```
 $ runghc Simulate.hs concept-examples/Concept.hs
Signal names: ["A","B","C"]
Circuit signals: 3

State: 000
Enabled: [A+,B+]
Do: A+
State: 100
Enabled: [B+]
Do: B+
State: 110
Enabled: [C+]
Do: C+
State: 111
Enabled: [A-,B-]
```
