### PR TITLE
Defined initial states will now be correctly translated.

### DIFF
--- a/examples/Celement_with_env_2.hs
+++ b/examples/Celement_with_env_2.hs
@@ -4,7 +4,7 @@ import Tuura.ConceptConcat
 
 -- C-element with environment circuit described using gate-level concepts
 circuit :: (Eq a) => a -> a -> a -> CircuitConcept a
-circuit a b c = interface <> cElement a b c <> environment <> initialState 
+circuit a b c = interface <> cElement a b c <> environment <> initialState
   where
     interface = inputs [a, b] <> outputs [c]
 
@@ -13,4 +13,4 @@ circuit a b c = interface <> cElement a b c <> environment <> initialState
     initialState = initialise a False <> initialise b False <> initialise c False
 
 
-    
+

--- a/examples/zcAbsent_scenario.hs
+++ b/examples/zcAbsent_scenario.hs
@@ -4,7 +4,7 @@ import Tuura.ConceptConcat
 
 --ZC absent scenario definition using concepts
 circuit :: Eq a => a -> a -> a -> a -> a -> a -> a -> CircuitConcept a
-circuit uv oc zc gp_ack gn_ack gp gn = 
+circuit uv oc zc gp_ack gn_ack gp gn =
     chargeFunc <> uvFunc <> uvReact -- <> zcAbsent
   where
     interface = inputs [uv, oc, zc, gp_ack, gn_ack] <> outputs [gp, gn]
@@ -21,9 +21,11 @@ circuit uv oc zc gp_ack gn_ack gp gn =
     gpHandshake = handshake gp gp_ack
     gnHandshake = handshake gn gn_ack
 
-    initialState = initialise uv False <> initialise oc False
+    initialState = initialise uv False <> initialise oc False <> initialise zc False <>
+                   initialise gp_ack False <> initialise gn_ack False <> initialise gp False
+                   <> initialise gn False
 
-    chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint 
+    chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint
                 <> circuitConstraint <> gpHandshake <> gnHandshake <> initialState
 
 --    zcAbsent = silent zc

--- a/examples/zcAbsent_scenario.hs
+++ b/examples/zcAbsent_scenario.hs
@@ -21,7 +21,7 @@ circuit uv oc zc gp_ack gn_ack gp gn =
     gpHandshake = handshake gp gp_ack
     gnHandshake = handshake gn gn_ack
 
-    initialState = initials [uv, oc, zc, gp_ack, gn_ack, gp, gn] False
+    initialState = initialise0 [uv, oc, zc, gp_ack, gn_ack, gp, gn]
 
     chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint
                 <> circuitConstraint <> gpHandshake <> gnHandshake <> initialState

--- a/examples/zcAbsent_scenario.hs
+++ b/examples/zcAbsent_scenario.hs
@@ -21,9 +21,7 @@ circuit uv oc zc gp_ack gn_ack gp gn =
     gpHandshake = handshake gp gp_ack
     gnHandshake = handshake gn gn_ack
 
-    initialState = initialise uv False <> initialise oc False <> initialise zc False <>
-                   initialise gp_ack False <> initialise gn_ack False <> initialise gp False
-                   <> initialise gn False
+    initialState = initials [uv, oc, zc, gp_ack, gn_ack, gp, gn] False
 
     chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint
                 <> circuitConstraint <> gpHandshake <> gnHandshake <> initialState

--- a/examples/zcEarly_scenario.hs
+++ b/examples/zcEarly_scenario.hs
@@ -26,9 +26,7 @@ circuit uv oc zc gp_ack gn_ack gp gn =
     gpHandshake = handshake gp gp_ack
     gnHandshake = handshake gn gn_ack
 
-    initialState = initialise uv False <> initialise oc False <> initialise zc False <>
-                   initialise gp_ack False <> initialise gn_ack False <> initialise gp False
-                   <> initialise gn False
+    initialState = initials [uv, oc, zc, gp_ack, gn_ack, gp, gn] False
 
     chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint
                 <> circuitConstraint <> gpHandshake <> gnHandshake <> initialState

--- a/examples/zcEarly_scenario.hs
+++ b/examples/zcEarly_scenario.hs
@@ -26,7 +26,7 @@ circuit uv oc zc gp_ack gn_ack gp gn =
     gpHandshake = handshake gp gp_ack
     gnHandshake = handshake gn gn_ack
 
-    initialState = initials [uv, oc, zc, gp_ack, gn_ack, gp, gn] False
+    initialState = initialise0 [uv, oc, zc, gp_ack, gn_ack, gp, gn]
 
     chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint
                 <> circuitConstraint <> gpHandshake <> gnHandshake <> initialState

--- a/examples/zcEarly_scenario.hs
+++ b/examples/zcEarly_scenario.hs
@@ -9,7 +9,7 @@ circuit uv oc zc gp_ack gn_ack gp gn =
   where
     interface = inputs [uv, oc, zc, gp_ack, gn_ack] <> outputs [gp, gn]
 
-    zcFunc = rise zc ~> fall gn 
+    zcFunc = rise zc ~> fall gn
     zcReact = fall oc ~> rise zc <> rise gp ~> fall zc
 
     uvFunc' = rise uv ~> rise gp
@@ -26,7 +26,9 @@ circuit uv oc zc gp_ack gn_ack gp gn =
     gpHandshake = handshake gp gp_ack
     gnHandshake = handshake gn gn_ack
 
-    initialState = initialise uv False <> initialise oc False
-    
-    chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint 
+    initialState = initialise uv False <> initialise oc False <> initialise zc False <>
+                   initialise gp_ack False <> initialise gn_ack False <> initialise gp False
+                   <> initialise gn False
+
+    chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint
                 <> circuitConstraint <> gpHandshake <> gnHandshake <> initialState

--- a/examples/zcLate_scenario.hs
+++ b/examples/zcLate_scenario.hs
@@ -24,7 +24,9 @@ circuit uv oc zc gp_ack gn_ack gp gn =
     gpHandshake = handshake gp gp_ack
     gnHandshake = handshake gn gn_ack
 
-    initialState = initialise uv False <> initialise oc False
+    initialState = initialise uv False <> initialise oc False <> initialise zc False <>
+                   initialise gp_ack False <> initialise gn_ack False <> initialise gp False
+                   <> initialise gn False
 
-    chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint 
+    chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint
                 <> circuitConstraint <> gpHandshake <> gnHandshake <> initialState

--- a/examples/zcLate_scenario.hs
+++ b/examples/zcLate_scenario.hs
@@ -24,9 +24,7 @@ circuit uv oc zc gp_ack gn_ack gp gn =
     gpHandshake = handshake gp gp_ack
     gnHandshake = handshake gn gn_ack
 
-    initialState = initialise uv False <> initialise oc False <> initialise zc False <>
-                   initialise gp_ack False <> initialise gn_ack False <> initialise gp False
-                   <> initialise gn False
+    initialState = initials [uv, oc, zc, gp_ack, gn_ack, gp, gn] False
 
     chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint
                 <> circuitConstraint <> gpHandshake <> gnHandshake <> initialState

--- a/examples/zcLate_scenario.hs
+++ b/examples/zcLate_scenario.hs
@@ -24,7 +24,7 @@ circuit uv oc zc gp_ack gn_ack gp gn =
     gpHandshake = handshake gp gp_ack
     gnHandshake = handshake gn gn_ack
 
-    initialState = initials [uv, oc, zc, gp_ack, gn_ack, gp, gn] False
+    initialState = initialise0 [uv, oc, zc, gp_ack, gn_ack, gp, gn]
 
     chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint
                 <> circuitConstraint <> gpHandshake <> gnHandshake <> initialState

--- a/src/Tuura/Concept/Concat/Abstract.hs
+++ b/src/Tuura/Concept/Concat/Abstract.hs
@@ -14,6 +14,11 @@ import Data.Monoid
 
 data Interface = Unused | Input | Output | Internal deriving (Ord, Eq, Show)
 
+instance Monoid Interface where
+    mempty = Unused
+
+    mappend x y = x `max` y
+
 data InitialValue = Undefined | Defined { getDefined :: Bool } | Inconsistent deriving (Eq, Show)
 
 instance Monoid InitialValue where
@@ -28,8 +33,8 @@ instance Monoid InitialValue where
 -- Note, type parameter s is unused in this implementation and may be removed later.
 data Concept s e a = Concept
                    {
-                       initial :: a -> InitialValue,
-                       arcs    :: [(e, e)],
+                       initial   :: a -> InitialValue,
+                       arcs      :: [(e, e)],
                        interface :: a -> Interface
                    }
 
@@ -44,7 +49,7 @@ instance Monoid (Concept s e a) where
                   {
                       initial = \s -> initial a s <> initial b s,
                       arcs    = arcs a     ++  arcs b,
-                      interface = \s -> interface a s `max` interface b s
+                      interface = \s -> interface a s <> interface b s
                   }
 
 arcConcept :: e -> e -> Concept s e a

--- a/src/Tuura/Concept/Concat/Abstract.hs
+++ b/src/Tuura/Concept/Concat/Abstract.hs
@@ -39,17 +39,13 @@ data Concept s e a = Concept
                    }
 
 instance Monoid (Concept s e a) where
-    mempty = Concept
-             {
-                 initial = const mempty,
-                 arcs    = [],
-                 interface = const Unused
-             }
+    mempty = Concept mempty mempty mempty
+
     mappend a b = Concept
                   {
-                      initial = \s -> initial a s <> initial b s,
-                      arcs    = arcs a     ++  arcs b,
-                      interface = \s -> interface a s <> interface b s
+                      initial   = initial a   <> initial b,
+                      arcs      = arcs a      <>  arcs b,
+                      interface = interface a <> interface b
                   }
 
 arcConcept :: e -> e -> Concept s e a

--- a/src/Tuura/Concept/Concat/Abstract.hs
+++ b/src/Tuura/Concept/Concat/Abstract.hs
@@ -17,7 +17,7 @@ data Interface = Unused | Input | Output | Internal deriving (Ord, Eq, Show)
 instance Monoid Interface where
     mempty = Unused
 
-    mappend x y = x `max` y
+    mappend = max
 
 data InitialValue = Undefined | Defined { getDefined :: Bool } | Inconsistent deriving (Eq, Show)
 

--- a/src/Tuura/Concept/Concat/Abstract.hs
+++ b/src/Tuura/Concept/Concat/Abstract.hs
@@ -12,7 +12,7 @@ import Data.Monoid
 -- * s is the type of states
 -- * e is the type of events
 
-data Interface = Unused | Input | Internal | Output deriving (Ord, Eq, Show)
+data Interface = Unused | Input | Output | Internal deriving (Ord, Eq, Show)
 
 data InitialValue = Undefined | Defined { getDefined :: Bool } | Inconsistent deriving (Eq, Show)
 
@@ -25,7 +25,7 @@ instance Monoid InitialValue where
     mappend x Undefined = x
     mappend (Defined x) (Defined y) = if x == y then Defined x else Inconsistent
 
-
+-- Note, type parameter s is unused in this implementation and may be removed later.
 data Concept s e a = Concept
                    {
                        initial :: a -> InitialValue,

--- a/src/Tuura/Concept/Concat/Circuit.hs
+++ b/src/Tuura/Concept/Concat/Circuit.hs
@@ -2,7 +2,7 @@ module Tuura.Concept.Concat.Circuit (
     State (..), Transition (..),
     rise, fall, toggle, oldValue, before, after,
     CircuitConcept,
-    consistency, initialise,
+    consistency, initialise, initials,
     (~>),
     buffer, inverter, cElement, meElement,
     me, handshake, handshake00, handshake11,
@@ -60,6 +60,9 @@ consistency = mempty
 
 initialise :: Eq a => a -> Bool -> CircuitConcept a
 initialise a v = initialConcept $ \s -> if s == a then Defined v else Undefined
+
+initials :: Eq a => [a] -> Bool -> CircuitConcept a
+initials as v = if (as /= []) then initialise (head as) v <> initials (tail as) v else mempty
 
 (~>) :: Transition a -> Transition a -> CircuitConcept a
 (~>) = arcConcept

--- a/src/Tuura/Concept/Concat/Circuit.hs
+++ b/src/Tuura/Concept/Concat/Circuit.hs
@@ -2,7 +2,8 @@ module Tuura.Concept.Concat.Circuit (
     State (..), Transition (..),
     rise, fall, toggle, oldValue, before, after,
     CircuitConcept,
-    consistency, initialise, initials,
+    consistency, initialise,
+    initialise0, initialise1,
     (~>),
     buffer, inverter, cElement, meElement,
     me, handshake, handshake00, handshake11,
@@ -61,8 +62,11 @@ consistency = mempty
 initialise :: Eq a => a -> Bool -> CircuitConcept a
 initialise a v = initialConcept $ \s -> if s == a then Defined v else Undefined
 
-initials :: Eq a => [a] -> Bool -> CircuitConcept a
-initials as v = if (as /= []) then initialise (head as) v <> initials (tail as) v else mempty
+initialise0 :: Eq a => [a] -> CircuitConcept a
+initialise0 as = if (as /= []) then initialise (head as) False <> initialise0 (tail as) else mempty
+
+initialise1 :: Eq a => [a] -> CircuitConcept a
+initialise1 as = if (as /= []) then initialise (head as) True <> initialise1 (tail as) else mempty
 
 (~>) :: Transition a -> Transition a -> CircuitConcept a
 (~>) = arcConcept

--- a/src/Tuura/Concept/Concat/Circuit.hs
+++ b/src/Tuura/Concept/Concat/Circuit.hs
@@ -58,8 +58,8 @@ type CircuitConcept a = Concept (State a) (Transition a) a
 consistency :: CircuitConcept a
 consistency = mempty
 
-initialise :: a -> Bool -> CircuitConcept a
-initialise a = initialConcept . after . Transition a
+initialise :: Eq a => a -> Bool -> CircuitConcept a
+initialise a v = initialConcept $ \s -> if s == a then Defined v else Undefined
 
 (~>) :: Transition a -> Transition a -> CircuitConcept a
 (~>) = arcConcept
@@ -74,20 +74,20 @@ inverter a b = rise a ~> fall b <> fall a ~> rise b
 cElement :: a -> a -> a -> CircuitConcept a
 cElement a b c = buffer a c <> buffer b c
 
-meElement :: a -> a -> a -> a -> CircuitConcept a
+meElement :: Eq a => a -> a -> a -> a -> CircuitConcept a
 meElement r1 r2 g1 g2 = buffer r1 g1 <> buffer r2 g2 <> me g1 g2
 
 -- Protocol-level concepts
 handshake :: a -> a -> CircuitConcept a
 handshake a b = buffer a b <> inverter b a
 
-handshake00 :: a -> a -> CircuitConcept a
+handshake00 :: Eq a => a -> a -> CircuitConcept a
 handshake00 a b = handshake a b <> initialise a False <> initialise b False
 
-handshake11 :: a -> a -> CircuitConcept a
+handshake11 :: Eq a => a -> a -> CircuitConcept a
 handshake11 a b = handshake a b <> initialise a True <> initialise b True
 
-me :: a -> a -> CircuitConcept a
+me :: Eq a => a -> a -> CircuitConcept a
 me a b = fall a ~> rise b <> fall b ~> rise a
       <> initialise a False <> initialise b False
 

--- a/translate/Main.hs
+++ b/translate/Main.hs
@@ -98,15 +98,21 @@ doTranslate :: MonadIO m => [DynSignal] -> Concept (State DynSignal) (Transition
 doTranslate signs circuit = do
     case validate signs circuit of
         Valid -> do
-            let initStrs = map (\s -> (show s, False)) signs {- TODO: don't hard-code to false -}
+            let initStrs = map (\s -> (show s, (getDefined $ initial circuit s))) signs
             let arcStrs = map (\(from, to) -> (show from, show to)) (arcs circuit)
             let inputSigns = filter ((==Input) . interface circuit) signs
             let outputSigns = filter ((==Output) . interface circuit) signs
             let internalSigns = filter ((==Internal) . interface circuit) signs
             liftIO $ putStr $ genSTG inputSigns outputSigns internalSigns initStrs arcStrs
             return ()
-        UnusedSignal ss -> liftIO $ putStr $ "Error. The following signals are not declared as input, output or internal: \n"
-            ++ unlines (map show ss)
+        Invalid ss is us -> liftIO $ do
+            putStr $ "Error. \n"
+            when (ss /= []) (putStr $ "The following signals are not declared as input, output or internal: \n"
+                                    ++ unlines (map show ss) ++ "\n")
+            when (is /= []) $ putStr $ "The following signals have inconsistent inital states: \n"
+                                    ++ unlines (map show is) ++ "\n"
+            when (us /= []) $ putStr $ "The following signals have undefined initial states: \n"
+                                    ++ unlines (map show us) ++ "\n"
 
 output :: [(String, Bool)] -> [String]
 output = sort . nub . map fst
@@ -138,7 +144,7 @@ tmpl :: String
 tmpl = unlines [".model out", ".inputs %s", ".outputs %s", ".internals %s", ".graph", "%s.marking {%s}", ".end"]
 
 genSTG :: [DynSignal] -> [DynSignal] -> [DynSignal] -> [(String, Bool)] -> [(String, String)] -> String
-genSTG inputSigns outputSigns internalSigns initStrs arcStrs = 
+genSTG inputSigns outputSigns internalSigns initStrs arcStrs =
     printf tmpl (unwords ins) (unwords outs) (unwords ints) (unlines trans) (unwords marks)
     where
         allSigns = output initStrs
@@ -148,9 +154,13 @@ genSTG inputSigns outputSigns internalSigns initStrs arcStrs =
         trans = concatMap symbLoop allSigns ++ concatMap transition arcStrs
         marks = initVals allSigns initStrs
 
-data ValidationResult a = Valid | UnusedSignal [a] deriving Eq
+data ValidationResult a = Valid | Invalid [a] [a] [a] deriving Eq
 
-validate :: [a] -> CircuitConcept a -> ValidationResult a
-validate signs circuit = case filter ((==Unused) . interface circuit) signs of
-    []     -> Valid
-    unused -> UnusedSignal unused
+validate :: Eq a => [a] -> CircuitConcept a -> ValidationResult a
+validate signs circuit
+    | unused ++ inconsistent ++ undef == [] = Valid
+    | otherwise                             = Invalid unused inconsistent undef
+  where
+    unused       = filter ((==Unused) . interface circuit) signs
+    inconsistent = filter ((==Inconsistent) . initial circuit) signs
+    undef        = filter ((==Undefined) . initial circuit) signs

--- a/translate/Main.hs
+++ b/translate/Main.hs
@@ -105,14 +105,14 @@ doTranslate signs circuit = do
             let internalSigns = filter ((==Internal) . interface circuit) signs
             liftIO $ putStr $ genSTG inputSigns outputSigns internalSigns initStrs arcStrs
             return ()
-        Invalid ss is us -> liftIO $ do
+        Invalid unused incons undef -> liftIO $ do
             putStr $ "Error. \n"
-            when (ss /= []) (putStr $ "The following signals are not declared as input, output or internal: \n"
-                                    ++ unlines (map show ss) ++ "\n")
-            when (is /= []) $ putStr $ "The following signals have inconsistent inital states: \n"
-                                    ++ unlines (map show is) ++ "\n"
-            when (us /= []) $ putStr $ "The following signals have undefined initial states: \n"
-                                    ++ unlines (map show us) ++ "\n"
+            when (unused /= []) (putStr $ "The following signals are not declared as input, output or internal: \n"
+                                    ++ unlines (map show unused) ++ "\n")
+            when (incons /= []) $ putStr $ "The following signals have inconsistent inital states: \n"
+                                    ++ unlines (map show incons) ++ "\n"
+            when (undef  /= []) $ putStr $ "The following signals have undefined initial states: \n"
+                                    ++ unlines (map show undef) ++ "\n"
 
 output :: [(String, Bool)] -> [String]
 output = sort . nub . map fst


### PR DESCRIPTION
Initial states will no longer be hard-coded as `False`.

I also included a new function to allow defining several of the same initial state for a list of signals at once, `initials`, for ease of use. 

All examples have been updated to conform to the requirements of the tool:
- All signals now must have their initial state defined. 
- The buck scenarios now use `initials` for clarity. 
- C-element examples continue to use the original `initialise` to show options when defining initial states.
