### PR TITLE
Changed gp and gp_ack initial states in buck examples to 1.

### DIFF
--- a/examples/zcAbsent_scenario.hs
+++ b/examples/zcAbsent_scenario.hs
@@ -20,7 +20,7 @@ circuit uv oc zc gp_ack gn_ack gp gn =
     gpHandshake = handshake gp gp_ack
     gnHandshake = handshake gn gn_ack
 
-    initialState = initialise0 [uv, oc, zc, gp_ack, gn_ack, gp, gn]
+    initialState = initialise0 [uv, oc, zc, gp_ack, gp] <> initialise1 [gn_ack, gn]
 
     chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint
                 <> circuitConstraint <> gpHandshake <> gnHandshake <> initialState

--- a/examples/zcAbsent_scenario.hs
+++ b/examples/zcAbsent_scenario.hs
@@ -20,9 +20,9 @@ circuit uv oc zc gp_ack gn_ack gp gn =
     gpHandshake = handshake gp gp_ack
     gnHandshake = handshake gn gn_ack
 
-    initialState = initialise0 [uv, oc, zc, gp_ack, gp] <> initialise1 [gn_ack, gn]
+    initialState = initialise0 [uv, oc, zc, gp, gp_ack] <> initialise1 [gn, gn_ack]
 
-    chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint
-                <> circuitConstraint <> gpHandshake <> gnHandshake <> initialState
+    chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint <>
+                 circuitConstraint <> gpHandshake <> gnHandshake <> initialState
 
 --    zcAbsent = silent zc

--- a/examples/zcEarly_scenario.hs
+++ b/examples/zcEarly_scenario.hs
@@ -25,7 +25,7 @@ circuit uv oc zc gp_ack gn_ack gp gn =
     gpHandshake = handshake gp gp_ack
     gnHandshake = handshake gn gn_ack
 
-    initialState = initialise0 [uv, oc, zc, gp_ack, gp] <> initialise1 [gn_ack, gn]
+    initialState = initialise0 [uv, oc, zc, gp, gp_ack] <> initialise1 [gn, gn_ack]
 
-    chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint
-                <> circuitConstraint <> gpHandshake <> gnHandshake <> initialState
+    chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint <>
+                 circuitConstraint <> gpHandshake <> gnHandshake <> initialState

--- a/examples/zcEarly_scenario.hs
+++ b/examples/zcEarly_scenario.hs
@@ -25,7 +25,7 @@ circuit uv oc zc gp_ack gn_ack gp gn =
     gpHandshake = handshake gp gp_ack
     gnHandshake = handshake gn gn_ack
 
-    initialState = initialise0 [uv, oc, zc, gp_ack, gn_ack, gp, gn]
+    initialState = initialise0 [uv, oc, zc, gp_ack, gp] <> initialise1 [gn_ack, gn]
 
     chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint
                 <> circuitConstraint <> gpHandshake <> gnHandshake <> initialState

--- a/examples/zcLate_scenario.hs
+++ b/examples/zcLate_scenario.hs
@@ -23,7 +23,7 @@ circuit uv oc zc gp_ack gn_ack gp gn =
     gpHandshake = handshake gp gp_ack
     gnHandshake = handshake gn gn_ack
 
-    initialState = initialise0 [uv, oc, zc, gp_ack, gn_ack, gp, gn]
+    initialState = initialise0 [uv, oc, zc, gp_ack, gp] <> initialise1 [gn_ack, gn]
 
     chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint
                 <> circuitConstraint <> gpHandshake <> gnHandshake <> initialState

--- a/examples/zcLate_scenario.hs
+++ b/examples/zcLate_scenario.hs
@@ -23,7 +23,7 @@ circuit uv oc zc gp_ack gn_ack gp gn =
     gpHandshake = handshake gp gp_ack
     gnHandshake = handshake gn gn_ack
 
-    initialState = initialise0 [uv, oc, zc, gp_ack, gp] <> initialise1 [gn_ack, gn]
+    initialState = initialise0 [uv, oc, zc, gp, gp_ack] <> initialise1 [gn, gn_ack]
 
-    chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint
-                <> circuitConstraint <> gpHandshake <> gnHandshake <> initialState
+    chargeFunc = interface <> ocFunc <> ocReact <> environmentConstraint <>
+                 circuitConstraint <> gpHandshake <> gnHandshake <> initialState

--- a/src/Tuura/Concept/STG/Circuit.hs
+++ b/src/Tuura/Concept/STG/Circuit.hs
@@ -94,6 +94,7 @@ handshake00 a b = handshake a b <> initialise a False <> initialise b False
 handshake11 :: Eq a => a -> a -> CircuitConcept a
 handshake11 a b = handshake a b <> initialise a True <> initialise b True
 
+-- TODO: Restrict the initial state so that a=b=1 is not allowed.
 me :: Eq a => a -> a -> CircuitConcept a
 me a b = fall a ~> rise b <> fall b ~> rise a
 

--- a/src/Tuura/Concept/STG/Circuit.hs
+++ b/src/Tuura/Concept/STG/Circuit.hs
@@ -96,7 +96,6 @@ handshake11 a b = handshake a b <> initialise a True <> initialise b True
 
 me :: Eq a => a -> a -> CircuitConcept a
 me a b = fall a ~> rise b <> fall b ~> rise a
-      <> initialise a False <> initialise b False
 
 -- Signal type declaration concepts
 inputs :: Eq a => [a] -> CircuitConcept a


### PR DESCRIPTION
Removed initial states from `me` to avoid issues with these examples, where an initial state is defined more than once.
