### PR TITLE
Implemented OR-causality.

### DIFF
--- a/src/Tuura/Concept/STG/Abstract.hs
+++ b/src/Tuura/Concept/STG/Abstract.hs
@@ -3,7 +3,7 @@ module Tuura.Concept.STG.Abstract (
     InitialValue (..),
     Concept (..),
     initialConcept, arcConcept,
-    interfaceConcept,
+    orCausality, interfaceConcept,
     ) where
 
 import Data.Monoid
@@ -35,21 +35,26 @@ data Concept s e a = Concept
                    {
                        initial   :: a -> InitialValue,
                        arcs      :: [(e, e)],
+                       ors       :: [([e], e)],
                        interface :: a -> Interface
                    }
 
 instance Monoid (Concept s e a) where
-    mempty = Concept mempty mempty mempty
+    mempty = Concept mempty mempty mempty mempty
 
     mappend a b = Concept
                   {
                       initial   = initial a   <> initial b,
-                      arcs      = arcs a      <>  arcs b,
+                      arcs      = arcs a      <> arcs b,
+                      ors       = ors a       <> ors b,
                       interface = interface a <> interface b
                   }
 
 arcConcept :: e -> e -> Concept s e a
 arcConcept from to = mempty { arcs = [(from, to)] }
+
+orCausality :: [e] -> e -> Concept s e a
+orCausality from to = mempty { ors = [(from, to)] }
 
 initialConcept :: (a -> InitialValue) -> Concept s e a
 initialConcept f = mempty { initial = f }

--- a/src/Tuura/Concept/STG/Abstract.hs
+++ b/src/Tuura/Concept/STG/Abstract.hs
@@ -34,27 +34,25 @@ instance Monoid InitialValue where
 data Concept s e a = Concept
                    {
                        initial   :: a -> InitialValue,
-                       arcs      :: [(e, e)],
-                       ors       :: [([e], e)],
+                       arcs      :: [([e], e)],
                        interface :: a -> Interface
                    }
 
 instance Monoid (Concept s e a) where
-    mempty = Concept mempty mempty mempty mempty
+    mempty = Concept mempty mempty mempty
 
     mappend a b = Concept
                   {
                       initial   = initial a   <> initial b,
                       arcs      = arcs a      <> arcs b,
-                      ors       = ors a       <> ors b,
                       interface = interface a <> interface b
                   }
 
 arcConcept :: e -> e -> Concept s e a
-arcConcept from to = mempty { arcs = [(from, to)] }
+arcConcept from to = mempty { arcs = [([from], to)] }
 
 orCausality :: [e] -> e -> Concept s e a
-orCausality from to = mempty { ors = [(from, to)] }
+orCausality from to = mempty { arcs = [(from, to)] }
 
 initialConcept :: (a -> InitialValue) -> Concept s e a
 initialConcept f = mempty { initial = f }

--- a/src/Tuura/Concept/STG/Abstract.hs
+++ b/src/Tuura/Concept/STG/Abstract.hs
@@ -60,4 +60,4 @@ initialConcept :: (a -> InitialValue) -> Concept s e a
 initialConcept f = mempty { initial = f }
 
 interfaceConcept :: (a -> Interface) -> Concept s e a
-interfaceConcept f = mempty {interface = f}
+interfaceConcept f = mempty { interface = f }

--- a/src/Tuura/Concept/STG/Circuit.hs
+++ b/src/Tuura/Concept/STG/Circuit.hs
@@ -4,7 +4,7 @@ module Tuura.Concept.STG.Circuit (
     CircuitConcept,
     consistency, initialise,
     initialise0, initialise1,
-    (~>),
+    (~>), (~|~>),
     buffer, inverter, cElement, meElement,
     me, handshake, handshake00, handshake11,
     inputs, outputs, internals
@@ -70,6 +70,9 @@ initialise1 as = if (as /= []) then initialise (head as) True <> initialise1 (ta
 
 (~>) :: Transition a -> Transition a -> CircuitConcept a
 (~>) = arcConcept
+
+(~|~>) :: [Transition a] -> Transition a -> CircuitConcept a
+(~|~>) = orCausality
 
 -- Gate-level concepts
 buffer :: a -> a -> CircuitConcept a

--- a/src/Tuura/Concept/STG/Circuit.hs
+++ b/src/Tuura/Concept/STG/Circuit.hs
@@ -6,8 +6,9 @@ module Tuura.Concept.STG.Circuit (
     initialise0, initialise1,
     (~>), (~|~>),
     buffer, inverter, cElement, meElement,
-    me, handshake, handshake00, handshake11,
-    inputs, outputs, internals
+    andGate, orGate, me, handshake,
+    handshake00, handshake11, inputs,
+    outputs, internals
     ) where
 
 import Tuura.Concept.STG.Abstract
@@ -86,6 +87,12 @@ cElement a b c = buffer a c <> buffer b c
 
 meElement :: a -> a -> a -> a -> CircuitConcept a
 meElement r1 r2 g1 g2 = buffer r1 g1 <> buffer r2 g2 <> me g1 g2
+
+andGate :: a -> a -> a -> CircuitConcept a
+andGate a b c = rise a ~> rise c <> rise b ~> rise c <> [fall a, fall b] ~|~> fall c
+
+orGate :: a -> a -> a -> CircuitConcept a
+orGate a b c = [rise a, rise b] ~|~> rise c <> fall a ~> fall c <> fall b ~> fall c
 
 -- Protocol-level concepts
 handshake :: a -> a -> CircuitConcept a

--- a/src/Tuura/Concept/STG/Circuit.hs
+++ b/src/Tuura/Concept/STG/Circuit.hs
@@ -84,7 +84,7 @@ inverter a b = rise a ~> fall b <> fall a ~> rise b
 cElement :: a -> a -> a -> CircuitConcept a
 cElement a b c = buffer a c <> buffer b c
 
-meElement :: Eq a => a -> a -> a -> a -> CircuitConcept a
+meElement :: a -> a -> a -> a -> CircuitConcept a
 meElement r1 r2 g1 g2 = buffer r1 g1 <> buffer r2 g2 <> me g1 g2
 
 -- Protocol-level concepts
@@ -98,7 +98,7 @@ handshake11 :: Eq a => a -> a -> CircuitConcept a
 handshake11 a b = handshake a b <> initialise a True <> initialise b True
 
 -- TODO: Restrict the initial state so that a=b=1 is not allowed.
-me :: Eq a => a -> a -> CircuitConcept a
+me :: a -> a -> CircuitConcept a
 me a b = fall a ~> rise b <> fall b ~> rise a
 
 -- Signal type declaration concepts

--- a/translate/Main.hs
+++ b/translate/Main.hs
@@ -99,12 +99,11 @@ doTranslate signs circuit = do
     case validate signs circuit of
         Valid -> do
             let initStrs = map (\s -> (show s, (getDefined $ initial circuit s))) signs
-            let arcStrs = map (\(from, to) -> (show from, show to)) (arcs circuit)
-            let orStrs = manageOrs (ors circuit) arcStrs
+            let arcStrs = handleArcs (arcs circuit)
             let inputSigns = filter ((==Input) . interface circuit) signs
             let outputSigns = filter ((==Output) . interface circuit) signs
             let internalSigns = filter ((==Internal) . interface circuit) signs
-            liftIO $ putStr $ genSTG inputSigns outputSigns internalSigns initStrs arcStrs orStrs
+            liftIO $ putStr $ genSTG inputSigns outputSigns internalSigns arcStrs initStrs
             return ()
         Invalid unused incons undef -> liftIO $ do
             putStr $ "Error. \n"
@@ -115,66 +114,35 @@ doTranslate signs circuit = do
             when (undef  /= []) $ putStr $ "The following signals have undefined initial states: \n"
                                     ++ unlines (map show undef) ++ "\n"
 
-manageOrs :: [([Transition DynSignal], Transition DynSignal)] -> [(String, String)] -> [String]
-manageOrs ors andArcs = do
-    let effect = snd (head ors)
+handleArcs :: [([Transition DynSignal], Transition DynSignal)] -> [String]
+handleArcs arcLists
+    | arcLists == [] = []
+    | otherwise = do
+    let effect = snd (head arcLists)
     -- Filter for just one of the effects
-    let orsForEffect = filter (\o -> snd o == effect) ors
-    let remainder = ors \\ orsForEffect
+    let causesForEffect = filter (\o -> snd o == effect) arcLists
     -- Get just the list of lists of causes
-    let causesLists = map (\l -> fst l) orsForEffect
+    let causesLists = map (\l -> fst l) causesForEffect
     -- Remap these
-    let mapped = mapOrs causesLists
+    let mapped = sequence causesLists
+    -- Length of this list of lists is the number of extra transitions to be added
     let n = length mapped
-    -- Create arc pairs for these ors
-    let orArcs = arcOrs mapped effect n
-    -- Create read-arcs for these
-    let orStrs = concatMap transition orArcs
-    -- Add new transitions to consistency loop
-    let consis = addSymbTransition effect n
-    -- Include arcs for and causality to all new transitions
-    let newAndArcs = updateAndArcs andArcs effect n
-    -- Combine all of these
-    let orStr = consis ++ orStrs ++ concatMap transition newAndArcs
-    if (remainder /= []) then orStr ++ manageOrs remainder andArcs else orStr
-
-updateAndArcs :: [(String, String)] -> Transition DynSignal -> Int -> [(String, String)]
-updateAndArcs andArcs effect n = do
-    let andsForEffect = filter (\a -> snd a == (show effect)) andArcs
-    concat (map (\s -> addAndArcs s n) andsForEffect)
-
-addAndArcs :: (String, String) -> Int -> [(String, String)]
-addAndArcs a n = map (\s -> (fst a, (snd a) ++ "/" ++ (show s))) [1..n - 1]
+    -- Create arc pairs for these arcs
+    let arcs = arcarcs mapped effect n
+    -- Get remaining arcs for other effects
+    let remainder = arcLists \\ causesForEffect
+    -- return [consistency loop additions] ++ [arc strings] ++ [the same result for other effects]
+    addSymbTransition effect n ++ concatMap transition arcs ++ handleArcs remainder
 
 addSymbTransition :: Transition DynSignal -> Int -> [String]
 addSymbTransition effect n
         | "+" `isSuffixOf` (show effect) = map (\x -> (printf "%s0 %s/%s\n" (init (show effect)) (show effect) (show x)) ++ (printf "%s/%s %s1" (show effect) (show x) (init (show effect)))) [1..n - 1]
         | otherwise                      = map (\x -> (printf "%s1 %s/%s\n" (init (show effect)) (show effect) (show x)) ++ (printf "%s/%s %s0" (show effect) (show x) (init (show effect)))) [1..n - 1]
 
-mapOrs :: [[Transition DynSignal]] -> [[Transition DynSignal]]
-mapOrs causesLists = addOrs (head causesLists) (tail causesLists)
-
-addOrs :: [Transition DynSignal] -> [[Transition DynSignal]] -> [[Transition DynSignal]]
-addOrs causes causesLists = do
-    concat (map (\c -> addOr c causesLists) causes)
-
-addOr :: Transition DynSignal -> [[Transition DynSignal]] -> [[Transition DynSignal]]
-addOr c causesLists
-        | causesLists == [] = [[c]]
-        | otherwise = do
-            let causes = head causesLists
-            let remainder = tail causesLists
-            concat (map (\d -> addOneToAll c (addOr d remainder)) causes)
-
-addOneToAll :: Transition DynSignal -> [[Transition DynSignal]] -> [[Transition DynSignal]]
-addOneToAll c causeLists
-        | causeLists == [] = []
-        | otherwise = [head causeLists ++ [c]] ++ addOneToAll c (tail causeLists)
-
-arcOrs :: [[Transition DynSignal]] -> Transition DynSignal -> Int -> [(String, String)]
-arcOrs causes effect n
+arcarcs :: [[Transition DynSignal]] -> Transition DynSignal -> Int -> [(String, String)]
+arcarcs causes effect n
         | n == 1 = map (\c -> (show c, show effect)) (head causes)
-        | otherwise = (map (\d -> (show d, (show effect  ++ "/" ++ show (n - 1)))) (head causes)) ++ arcOrs (tail causes) effect (n - 1)
+        | otherwise = (map (\d -> (show d, (show effect  ++ "/" ++ show (n - 1)))) (head causes)) ++ arcarcs (tail causes) effect (n - 1)
 
 output :: [(String, Bool)] -> [String]
 output = sort . nub . map fst
@@ -203,19 +171,19 @@ initVal s ((ls,v):l)
 initVal _ _ = 0
 
 tmpl :: String
-tmpl = unlines [".model out", ".inputs %s", ".outputs %s", ".internals %s", ".graph", "%s%s.marking {%s}", ".end"]
+tmpl = unlines [".model out", ".inputs %s", ".outputs %s", ".internals %s", ".graph", "%s.marking {%s}", ".end"]
 
-genSTG :: [DynSignal] -> [DynSignal] -> [DynSignal] -> [(String, Bool)] -> [(String, String)] -> [String] -> String
-genSTG inputSigns outputSigns internalSigns initStrs arcStrs orStrs =
-    printf tmpl (unwords ins) (unwords outs) (unwords ints) (unlines trans) (unlines orStrs) (unwords marks)
+genSTG :: [DynSignal] -> [DynSignal] -> [DynSignal] -> [String] -> [(String, Bool)] -> String
+genSTG inputSigns outputSigns internalSigns arcStrs initStrs =
+    printf tmpl (unwords ins) (unwords outs) (unwords ints) (unlines arcs) (unwords marks)
     where
         allSigns = output initStrs
         outs = map show outputSigns
         ins = map show inputSigns
         ints = map show internalSigns
-        trans = concatMap symbLoop allSigns ++ concatMap transition arcStrs
+        arcs = concatMap symbLoop allSigns ++ arcStrs
         marks = initVals allSigns initStrs
-        --ors = concatMap transition orStrs
+
 
 data ValidationResult a = Valid | Invalid [a] [a] [a] deriving Eq
 

--- a/translate/Main.hs
+++ b/translate/Main.hs
@@ -122,7 +122,7 @@ manageOrs ors andArcs = do
     let orsForEffect = filter (\o -> snd o == effect) ors
     let remainder = ors \\ orsForEffect
     -- Get just the list of lists of causes
-    let causesLists = map (\l -> fst l) ors
+    let causesLists = map (\l -> fst l) orsForEffect
     -- Remap these
     let mapped = mapOrs causesLists
     let n = length mapped
@@ -137,7 +137,6 @@ manageOrs ors andArcs = do
     -- Combine all of these
     let orStr = consis ++ orStrs ++ concatMap transition newAndArcs
     if (remainder /= []) then orStr ++ manageOrs remainder andArcs else orStr
-    --if (remainder /= []) then orArcs ++ manageOrs remainder else orArcs
 
 updateAndArcs :: [(String, String)] -> Transition DynSignal -> Int -> [(String, String)]
 updateAndArcs andArcs effect n = do
@@ -145,7 +144,7 @@ updateAndArcs andArcs effect n = do
     concat (map (\s -> addAndArcs s n) andsForEffect)
 
 addAndArcs :: (String, String) -> Int -> [(String, String)]
-addAndArcs a n = [a] ++ map (\s -> (fst a, (snd a) ++ "/" ++ (show s))) [1..n - 1]
+addAndArcs a n = map (\s -> (fst a, (snd a) ++ "/" ++ (show s))) [1..n - 1]
 
 addSymbTransition :: Transition DynSignal -> Int -> [String]
 addSymbTransition effect n
@@ -175,7 +174,7 @@ addOneToAll c causeLists
 arcOrs :: [[Transition DynSignal]] -> Transition DynSignal -> Int -> [(String, String)]
 arcOrs causes effect n
         | n == 1 = map (\c -> (show c, show effect)) (head causes)
-        | otherwise = (map (\c -> (show c, (show effect  ++ "/" ++ show (n - 1)))) (head causes)) ++ arcOrs (tail causes) effect (n - 1)
+        | otherwise = (map (\d -> (show d, (show effect  ++ "/" ++ show (n - 1)))) (head causes)) ++ arcOrs (tail causes) effect (n - 1)
 
 output :: [(String, Bool)] -> [String]
 output = sort . nub . map fst
@@ -205,9 +204,6 @@ initVal _ _ = 0
 
 tmpl :: String
 tmpl = unlines [".model out", ".inputs %s", ".outputs %s", ".internals %s", ".graph", "%s%s.marking {%s}", ".end"]
-
-printOrs :: (String, String) -> [String]
-printOrs (f, t) = [f ++ " " ++ t]
 
 genSTG :: [DynSignal] -> [DynSignal] -> [DynSignal] -> [(String, Bool)] -> [(String, String)] -> [String] -> String
 genSTG inputSigns outputSigns internalSigns initStrs arcStrs orStrs =


### PR DESCRIPTION
The algorithm for this I will display in a blog post. For now, here is some testing information. The test files are here: 
[Or-causality testing.zip](https://github.com/tuura/concepts/files/472367/Or-causality.testing.zip)

OR-gate C = A+B:
Works as expected. Synthesis produces this circuit:
[circuit_or_gate.pdf](https://github.com/tuura/concepts/files/472381/circuit_or_gate.pdf)

AND-gate C = AB:
Also works as expected. Synthesis produces this circuit:
[circuit_and_gate.pdf](https://github.com/tuura/concepts/files/472382/circuit_and_gate.pdf)

Two OR-gates - C = (A+B)(D+E):
Synthesis produces a predictably complex circuit, but simulation of the STG reveals it to work as expected.
To set `C` high (minimum): `A+` and `D+`.  `A+` and `E+`.  `B+` and `D+`.  `B+` and `E+`.
To set `C` low: All signals low

AND and OR gate - C = (A+B)DE:
Again, synthesis produces something unrecognizable. Simulation reveals correctness:
To set `C` high (minimum): `A+`, `D+` and `E+`. `B+`, `D+` and `E+`. 
To set `C` low (minimum): `A-`, `B-` and `E-`. `A-`, `B-` and `D-`. 

A 2-input OR and a 3-input OR - C = (A+B)(D+E+F):
Synthesis doesn't produce much, but simulation is good:
To set `C` high (minimum): `A+` and `D+`. `A+` and `E+`. `A+` and `F+`. `B+` and `D+`. `B+` and `E+`. `B+` and `F+`.
To set `C` low: All signals low

Let me know if you have any other test cases you wish me to try.
