### PR TITLE
Invariant information printed for STG will not include blank lines

### DIFF
--- a/TransTest.hs
+++ b/TransTest.hs
@@ -43,7 +43,8 @@ testDotGOutput = do
                        , "C1 C-"
                        , "C- C0"
                        , ".marking {A0 B1 C0}"
-                       , ".end"]
+                       , ".end"
+                       , ""]
 
 testHandshakeConcept :: IO ()
 testHandshakeConcept = do

--- a/src/Tuura/Concept/STG/Translation.hs
+++ b/src/Tuura/Concept/STG/Translation.hs
@@ -72,7 +72,7 @@ transition (f, t)
         | otherwise  = readArc (init (show f) ++ "0") t
 
 tmpl :: String
-tmpl = unlines [".model out", ".inputs %s", ".outputs %s", ".internal %s", ".graph", "%s.marking {%s}", ".end%s"]
+tmpl = unlines [".model out", ".inputs %s", ".outputs %s", ".internal %s", ".graph", "%s.marking {%s}", ".end", "%s"]
 
 output :: [(String, Bool)] -> [String]
 output = nubOrd . map fst
@@ -92,6 +92,6 @@ readArc f t = [f ++ " " ++ t, t ++ " " ++ f]
 genInvStrs :: (Ord a, Show a) => Invariant (Transition a) -> String
 genInvStrs (NeverAll es)
         | es        == [] = []
-        | otherwise = "\ninvariant = not (" ++  (intercalate " && " (map format es)) ++ ")"
+        | otherwise = "invariant = not (" ++  (intercalate " && " (map format es)) ++ ")"
     where
         format e = if (newValue e) then show (signal e) else "not " ++ show (signal e)


### PR DESCRIPTION
Noticed an issue when testing with Workcraft. This is a quick fix.

Invariant information would print with blank lines in between. Quite annoying. 