### PR TITLE
Reconfigured causality  to use OR-causality as the base.

### DIFF
--- a/SimTest.hs
+++ b/SimTest.hs
@@ -43,7 +43,8 @@ data Signal = A | B | C deriving (Eq, Show, Enum, Bounded)
 shouldBe :: (Eq a, Show a) => a -> a -> Simulation Signal IO ()
 shouldBe x y = lift $ assertEq x y
 
-shouldReturn :: (Eq a, Show a) => Simulation Signal IO a -> a -> Simulation Signal IO ()
+shouldReturn :: (Eq a, Show a) => Simulation Signal IO a -> a ->
+                Simulation Signal IO ()
 shouldReturn x y = x >>= (`shouldBe` y)
 
 bufferSimulation :: Simulation Signal IO ()
@@ -85,7 +86,8 @@ cElementGateLevelSimulation = do
     enabledTransitions circuit `shouldReturn` [fall A, fall B]
   where
     initialState = State $ const False
-    circuit      = consistency <> cElement A B C <> inverter C A <> inverter C B
+    circuit      = consistency <> cElement A B C
+                <> inverter C A <> inverter C B
 
 cElementProtocolLevelSimulation :: Simulation Signal IO ()
 cElementProtocolLevelSimulation = do

--- a/TransTest.hs
+++ b/TransTest.hs
@@ -52,7 +52,7 @@ testHandshakeConcept = do
     assertEq (sort (arcs handshakeConcept)) (sort expected)
   where
     handshakeConcept = inputs[a] <> outputs [b] <> handshake00 a b
-    expected = [AndCausality (rise a) (rise b), AndCausality (rise b) (fall a), AndCausality (fall a) (fall b), AndCausality (fall b) (rise a)]
+    expected = [Causality [rise a] (rise b), Causality [rise b] (fall a), Causality [fall a] (fall b), Causality [fall b] (rise a)]
     [a, b] = map Signal [0 .. 1]
 
 testOrGateConcept :: IO ()
@@ -61,7 +61,7 @@ testOrGateConcept = do
     assertEq (sort (arcs orGateConcept)) (sort expected)
   where
     orGateConcept = inputs [a, b] <> outputs [c] <> initialise0 [a, b, c] <> orGate a b c
-    expected = [OrCausality [rise a, rise b] (rise c), AndCausality (fall a) (fall c), AndCausality (fall b) (fall c)]
+    expected = [Causality [rise a, rise b] (rise c), Causality [fall a] (fall c), Causality [fall b] (fall c)]
     [a, b, c] = map Signal [0..2]
 
 testTwoAndGates :: IO ()
@@ -70,8 +70,8 @@ testTwoAndGates = do
     assertEq (sort (arcs twoAndGatesConcept)) (sort expected)
   where
     twoAndGatesConcept = inputs [a, b, c, d] <> outputs [out] <> initialise0 [a, b, c, d, out] <> andGate a b out <> andGate c d out
-    expected = [AndCausality (rise a) (rise out), AndCausality (rise b) (rise out), AndCausality (rise c) (rise out),
-                AndCausality (rise d) (rise out), OrCausality [fall a, fall b] (fall out), OrCausality [fall c, fall d] (fall out)]
+    expected = [Causality [rise a] (rise out), Causality [rise b] (rise out), Causality [rise c] (rise out),
+                Causality [rise d] (rise out), Causality [fall a, fall b] (fall out), Causality [fall c, fall d] (fall out)]
     [a, b, c, d, out] = map Signal [0..4]
 
 testTwoDifferentCElements :: IO ()

--- a/TransTest.hs
+++ b/TransTest.hs
@@ -20,7 +20,8 @@ testDotGOutput = do
     putStrLn "=== testDotGOutput"
     assertEq threeSignalsConcept expected
   where
-    threeSignalsConcept = translate (inputs [a] <> outputs [b] <> internals [c] <> initialise0 [a, c] <> initialise1 [b]) signs
+    threeSignalsConcept = translate (inputs [a] <> outputs [b] <> internals [c]
+                       <> initialise0 [a, c] <> initialise1 [b]) signs
     a = Signal 0
     b = Signal 1
     c = Signal 2
@@ -52,7 +53,8 @@ testHandshakeConcept = do
     assertEq (sort (arcs handshakeConcept)) (sort expected)
   where
     handshakeConcept = inputs[a] <> outputs [b] <> handshake00 a b
-    expected = [Causality [rise a] (rise b), Causality [rise b] (fall a), Causality [fall a] (fall b), Causality [fall b] (rise a)]
+    expected = [Causality [rise a] (rise b), Causality [rise b] (fall a),
+                Causality [fall a] (fall b), Causality [fall b] (rise a)]
     [a, b] = map Signal [0 .. 1]
 
 testOrGateConcept :: IO ()
@@ -60,8 +62,10 @@ testOrGateConcept = do
     putStrLn "===testOrGateConcept"
     assertEq (sort (arcs orGateConcept)) (sort expected)
   where
-    orGateConcept = inputs [a, b] <> outputs [c] <> initialise0 [a, b, c] <> orGate a b c
-    expected = [Causality [rise a, rise b] (rise c), Causality [fall a] (fall c), Causality [fall b] (fall c)]
+    orGateConcept = inputs [a, b] <> outputs [c]
+                 <> initialise0 [a, b, c] <> orGate a b c
+    expected = [Causality [rise a, rise b] (rise c),
+                Causality [fall a] (fall c), Causality [fall b] (fall c)]
     [a, b, c] = map Signal [0..2]
 
 testTwoAndGates :: IO ()
@@ -69,18 +73,26 @@ testTwoAndGates = do
     putStrLn "===testTwoAndGates"
     assertEq (sort (arcs twoAndGatesConcept)) (sort expected)
   where
-    twoAndGatesConcept = inputs [a, b, c, d] <> outputs [out] <> initialise0 [a, b, c, d, out] <> andGate a b out <> andGate c d out
-    expected = [Causality [rise a] (rise out), Causality [rise b] (rise out), Causality [rise c] (rise out),
-                Causality [rise d] (rise out), Causality [fall a, fall b] (fall out), Causality [fall c, fall d] (fall out)]
+    twoAndGatesConcept = inputs [a, b, c, d] <> outputs [out]
+                      <> initialise0 [a, b, c, d, out] <> andGate a b out
+                      <> andGate c d out
+    expected = [Causality [rise a] (rise out), Causality [rise b] (rise out),
+                Causality [rise c] (rise out), Causality [rise d] (rise out),
+                Causality [fall a, fall b] (fall out),
+                Causality [fall c, fall d] (fall out)]
     [a, b, c, d, out] = map Signal [0..4]
 
 testTwoDifferentCElements :: IO ()
 testTwoDifferentCElements = do
     putStrLn "===testTwoDifferentCElements"
-    assertEq (sort (arcs cElementConcept)) (sort (arcs cElementConceptFromBuffers))
+    assertEq (sort (arcs cElementConcept))
+             (sort (arcs cElementConceptFromBuffers))
   where
-    cElementConcept = inputs [a, b] <> outputs [c] <> initialise0 [a, b, c] <> cElement a b c
-    cElementConceptFromBuffers = inputs [a, b] <> outputs [c] <> initialise0 [a, b, c] <> buffer a c <> buffer b c
+    cElementConcept = inputs [a, b] <> outputs [c]
+                   <> initialise0 [a, b, c] <> cElement a b c
+    cElementConceptFromBuffers = inputs [a, b] <> outputs [c]
+                              <> initialise0 [a, b, c] <> buffer a c
+                              <> buffer b c
     [a, b, c] = map Signal [0..2]
 
 assertEq :: (Eq a, Show a) => a -> a -> IO ()

--- a/src/Tuura/Concept/Circuit/Basic.hs
+++ b/src/Tuura/Concept/Circuit/Basic.hs
@@ -24,7 +24,8 @@ instance Monoid Interface where
 
     mappend = max
 
-data InitialValue = Undefined | Defined { getDefined :: Bool } | Inconsistent deriving (Eq, Show)
+data InitialValue = Undefined | Defined { getDefined :: Bool } | Inconsistent
+                    deriving (Eq, Show)
 
 instance Monoid InitialValue where
     mempty = Undefined
@@ -33,11 +34,13 @@ instance Monoid InitialValue where
     mappend _ Inconsistent = Inconsistent
     mappend Undefined x = x
     mappend x Undefined = x
-    mappend (Defined x) (Defined y) = if x == y then Defined x else Inconsistent
+    mappend (Defined x) (Defined y) = if x == y
+                                      then Defined x
+                                      else Inconsistent
 
 data Invariant e = NeverAll [e] deriving (Eq, Show)
 
--- Note, type parameter s is unused in this implementation and may be removed later.
+-- Note, type parameter s is unused in this implementation and may be removed.
 data Concept s e a = Concept
                    {
                        initial   :: a -> InitialValue,

--- a/src/Tuura/Concept/Circuit/Basic.hs
+++ b/src/Tuura/Concept/Circuit/Basic.hs
@@ -15,7 +15,7 @@ import Data.Monoid
 -- * s is the type of states
 -- * e is the type of events
 
-data Causality e = AndCausality e e | OrCausality [e] e deriving (Ord, Eq, Show)
+data Causality e = Causality [e] e deriving (Ord, Eq, Show)
 
 data Interface = Unused | Input | Output | Internal deriving (Ord, Eq, Show)
 
@@ -58,10 +58,10 @@ instance Monoid (Concept s e a) where
                   }
 
 arcConcept :: e -> e -> Concept s e a
-arcConcept from to = mempty { arcs = [AndCausality from to] }
+arcConcept from to = mempty { arcs = [Causality [from] to] }
 
 orCausality :: [e] -> e -> Concept s e a
-orCausality from to = mempty { arcs = [OrCausality from to] }
+orCausality from to = mempty { arcs = [Causality from to] }
 
 initialConcept :: (a -> InitialValue) -> Concept s e a
 initialConcept f = mempty { initial = f }

--- a/src/Tuura/Concept/Circuit/Derived.hs
+++ b/src/Tuura/Concept/Circuit/Derived.hs
@@ -64,14 +64,12 @@ initialise :: Eq a => a -> Bool -> CircuitConcept a
 initialise a v = initialConcept $ \s -> if s == a then Defined v else Undefined
 
 initialise0 :: Eq a => [a] -> CircuitConcept a
-initialise0 as = if (as /= [])
-                 then initialise (head as) False <> initialise0 (tail as)
-                 else mempty
+initialise0 [] = mempty
+initialise0 as = initialise (head as) False <> initialise0 (tail as)
 
 initialise1 :: Eq a => [a] -> CircuitConcept a
-initialise1 as = if (as /= [])
-                 then initialise (head as) True <> initialise1 (tail as)
-                 else mempty
+initialise1 [] = mempty
+initialise1 as = initialise (head as) True <> initialise1 (tail as)
 
 (~>) :: Transition a -> Transition a -> CircuitConcept a
 (~>) = arcConcept

--- a/src/Tuura/Concept/Circuit/Derived.hs
+++ b/src/Tuura/Concept/Circuit/Derived.hs
@@ -64,10 +64,14 @@ initialise :: Eq a => a -> Bool -> CircuitConcept a
 initialise a v = initialConcept $ \s -> if s == a then Defined v else Undefined
 
 initialise0 :: Eq a => [a] -> CircuitConcept a
-initialise0 as = if (as /= []) then initialise (head as) False <> initialise0 (tail as) else mempty
+initialise0 as = if (as /= [])
+                 then initialise (head as) False <> initialise0 (tail as)
+                 else mempty
 
 initialise1 :: Eq a => [a] -> CircuitConcept a
-initialise1 as = if (as /= []) then initialise (head as) True <> initialise1 (tail as) else mempty
+initialise1 as = if (as /= [])
+                 then initialise (head as) True <> initialise1 (tail as)
+                 else mempty
 
 (~>) :: Transition a -> Transition a -> CircuitConcept a
 (~>) = arcConcept
@@ -89,10 +93,12 @@ meElement :: a -> a -> a -> a -> CircuitConcept a
 meElement r1 r2 g1 g2 = buffer r1 g1 <> buffer r2 g2 <> me g1 g2
 
 andGate :: a -> a -> a -> CircuitConcept a
-andGate a b c = rise a ~> rise c <> rise b ~> rise c <> [fall a, fall b] ~|~> fall c
+andGate a b c = rise a ~> rise c <> rise b ~> rise c
+             <> [fall a, fall b] ~|~> fall c
 
 orGate :: a -> a -> a -> CircuitConcept a
-orGate a b c = [rise a, rise b] ~|~> rise c <> fall a ~> fall c <> fall b ~> fall c
+orGate a b c = [rise a, rise b] ~|~> rise c
+            <> fall a ~> fall c <> fall b ~> fall c
 
 -- Protocol-level concepts
 handshake :: a -> a -> CircuitConcept a
@@ -112,10 +118,19 @@ never es = invariantConcept (NeverAll es)
 
 -- Signal type declaration concepts
 inputs :: Eq a => [a] -> CircuitConcept a
-inputs ins = interfaceConcept $ \s -> if s `elem` ins then Input else Unused
+inputs ins = interfaceConcept $ \s ->
+             if s `elem` ins
+             then Input
+             else Unused
 
 outputs :: Eq a => [a] -> CircuitConcept a
-outputs outs = interfaceConcept $ \s -> if s `elem` outs then Output else Unused
+outputs outs = interfaceConcept $ \s ->
+               if s `elem` outs
+               then Output
+               else Unused
 
 internals :: Eq a => [a] -> CircuitConcept a
-internals ints = interfaceConcept $ \s -> if s `elem` ints then Internal else Unused
+internals ints = interfaceConcept $ \s ->
+                 if s `elem` ints
+                 then Internal
+                 else Unused

--- a/src/Tuura/Concept/Examples/SimpleBuck.hs
+++ b/src/Tuura/Concept/Examples/SimpleBuck.hs
@@ -23,6 +23,7 @@ zcAbsentScenario uv oc zc gp gp_ack gn gn_ack =
 
     initialState = initialise uv False <> initialise oc False
 
-    chargeFunc = ocFunc <> ocReact <> environmentConstraint <> circuitConstraint <> gpHandshake <> gnHandshake
+    chargeFunc = ocFunc <> ocReact <> environmentConstraint
+              <> circuitConstraint <> gpHandshake <> gnHandshake
 
     zcAbsent = silent zc

--- a/src/Tuura/Concept/FSM/Translation.hs
+++ b/src/Tuura/Concept/FSM/Translation.hs
@@ -90,25 +90,22 @@ translate circuit signs =
     case validateInitialState signs circuit of
       Valid -> do
           let allCause = addConsistency (arcs circuit) signs
-              sortedCause = concatMap handleArcs
-                            (groupAllWith snd (arcLists allCause))
+              groupByEffect = groupAllWith snd (arcLists allCause)
+              sortedCause = concatMap handleArcs groupByEffect
               initState = getInitialState circuit signs
               allArcs = createAllArcs sortedCause
-              reachables = findReachables allArcs initState
-              invariants = concatMap (\i ->
-                           getInvariantStates i signs)
-                           (invariant circuit)
-              invariantNos = map encToInt invariants
-              reachableArcs = removeUnreachables allArcs reachables
+              reach = findReachables allArcs initState
+              invarConcepts = invariant circuit
+              invariants = concatMap (getInvariantStates signs) invarConcepts
+              encodedInvs = map encToInt invariants
+              reachableArcs = removeUnreachables allArcs reach
               inputSigns = filter ((==Input) . interface circuit) signs
               outputSigns = filter ((==Output) . interface circuit) signs
               internalSigns = filter ((==Internal) . interface circuit) signs
-              reachableInvariants = filter (\i ->
-                                    (encToInt i) `elem` reachables)
-                                    invariants
-              unreachables = ([0..2^(length signs) - 1]
-                              \\ invariantNos) \\ reachables
-          case (validateFSM signs reachableInvariants (invariant circuit))
+              reachInvs = filter (\i -> (encToInt i) `elem` reach) invariants
+              allStates = [0..2^(length signs) - 1]
+              unreachables = (allStates \\ encodedInvs) \\ reach
+          case (validateFSM signs reachInvs (invariant circuit))
                <> (validateInterface signs circuit) of
               Valid -> do
                   let reachReport = genReachReport unreachables
@@ -126,34 +123,32 @@ getInitialState circuit signs = encToInt state
 fromBool :: Bool -> Tristate
 fromBool x = if x then triTrue else triFalse
 
-addConsistency :: Ord a => [Causality (Transition a)] -> [a] ->
-                           [Causality (Transition a)]
-addConsistency allArcs signs = nubOrd (allArcs ++ concatMap (\s ->
-                               [Causality [rise s] (fall s),
-                                Causality [fall s] (rise s)])
-                               signs)
+addConsistency :: Ord a => [Causality (Transition a)] -> [a]
+                        -> [Causality (Transition a)]
+addConsistency allArcs signs = nubOrd (allArcs ++ consisArcs)
+  where
+    consisArcs = concatMap (genConsis) signs
+    genConsis s = [Causality [rise s] (fall s), Causality [fall s] (rise s)]
 
-handleArcs :: Ord a => NonEmpty ([Transition a], Transition a) ->
-              [([Transition a], Transition a)]
+handleArcs :: Ord a => NonEmpty ([Transition a], Transition a)
+                    -> [([Transition a], Transition a)]
 handleArcs xs = map (\m -> (m, effect)) transCauses
-        where
-            effect = snd (NonEmpty.head xs)
-            effectCauses = NonEmpty.map fst xs
-            transCauses = cartesianProduct effectCauses
+  where
+    effect = snd (NonEmpty.head xs)
+    effectCauses = NonEmpty.map fst xs
+    transCauses = cartesianProduct effectCauses
 
-validateFSM :: Ord a => [a] -> [[Tristate]] -> [Invariant (Transition a)] ->
-               ValidationResult a
+validateFSM :: Ord a => [a] -> [[Tristate]] -> [Invariant (Transition a)]
+                     -> ValidationResult a
 validateFSM signs reachInvs invs
     | invVio == [] = Valid
     | otherwise = Invalid (map InvariantViolated invVio)
   where
-    invsMapped = map (\(NeverAll is) ->
-                 (is, getInvariantStates (NeverAll is) signs))
-                 invs
-    invVio = nubOrd (map fst
-               (concatMap (\i ->
-               filter (\(_, x) -> i `elem` x) invsMapped)
-               reachInvs))
+    invVio = nubOrd (map fst check)
+    check = concatMap (\i -> filter (\(_, x) -> i `elem` x) mapInvs) reachInvs
+    mapInvs = map (\(NeverAll is) -> (is, invStates is)) invs
+    invStates is = getInvariantStates signs (NeverAll is)
+
 
 genFSM :: Show a => [a] -> [a] -> [a] -> [String] -> String -> String -> String
 genFSM inputSigns outputSigns internalSigns arcStrs initState reachReport =
@@ -163,10 +158,10 @@ genFSM inputSigns outputSigns internalSigns arcStrs initState reachReport =
                  (unlines arcStrs)
                  initState
                  reachReport
-    where
-      outs = map show outputSigns
-      ins = map show inputSigns
-      ints = map show internalSigns
+  where
+    outs = map show outputSigns
+    ins = map show inputSigns
+    ints = map show internalSigns
 
 genReachReport :: (Show a) => [a] -> String
 genReachReport [] = "\ninvariant = reachability\n"
@@ -174,8 +169,8 @@ genReachReport es = "\nWarning:\n" ++
                     "The following state(s) hold for the invariant " ++
                     "but are not reachable:\n" ++
                     unlines (unreachStates)
-    where
-      unreachStates = [ "s" ++ show e | e <- es ]
+  where
+    unreachStates = [ "s" ++ show e | e <- es ]
 
 tmpl :: String
 tmpl = unlines [".inputs %s",
@@ -192,12 +187,15 @@ fullListm :: ([TransitionX a], Transition a) -> [TransitionX a]
 fullListm (l,t) = (toTransitionX t):l
 
 -- Given [([a], b)], remove all b from a
-removeDupes :: Eq a => [([Transition a], Transition a)] ->
-                       [([Transition a], Transition a)]
--- (filter ((/= ((signal . snd) x)) . signal) (fst x), snd x)
-removeDupes = map (ap
-              ((,) . ap (filter . (. signal) . (/=) . signal . snd) fst)
-              snd)
+removeDupes :: Eq a => [([Transition a], Transition a)]
+                    -> [([Transition a], Transition a)]
+removeDupes xs = map removeDupe1 xs
+  where
+    removeDupe1 x = (filterDupes x, effect x)
+    filterDupes x = filter ((/= (effectSignal x)) . signal) (causes x)
+    effectSignal x = signal (effect x)
+    effect x = snd x
+    causes x = fst x
 
 toTransitionX :: Transition a -> TransitionX a
 toTransitionX = liftM2 TransitionX signal (Tristate . Just . newValue)
@@ -214,58 +212,60 @@ addMissingSignals :: Ord a => [([Transition a], Transition a)] -> CausalityX a
 addMissingSignals x = zip
                       (zipWith (++) newTransitions oldTransitions)
                       (map snd noDupes)
-    where noDupes = removeDupes x
-          oldTransitions = map (map toTransitionX . fst) noDupes
-          newTransitions = ((map . map) (flip TransitionX triX) .
-                           missingSignals . transitionList)
-                           noDupes
-          transitionList =  map fullList
-          missingSignals y = map (getAllSignals y \\) (onlySignals y)
+  where
+    noDupes = removeDupes x
+    oldTransitions = map (map toTransitionX . fst) noDupes
+    newTransitions = ((map . map) (flip TransitionX triX) .
+                     missingSignals . transitionList)
+                     noDupes
+    transitionList =  map fullList
+    missingSignals y = map (getAllSignals y \\) (onlySignals y)
 
 encode :: Ord a => [TransitionX a] -> [Tristate]
 encode  = map mnewValue . sortTransitions
-    where sortTransitions = sortBy (comparing msignal)
+  where
+    sortTransitions = sortBy (comparing msignal)
 
 createArcs :: Ord a => [([Transition a], Transition a)] -> [FsmArcX a]
 createArcs xs = zipWith3 createArc makeSrcEncs makeDestEncs activeTransitions
-    where createArc senc tenc xTrans = FsmArcX senc xTrans tenc
-          makeDestEncs = a xs
-          makeSrcEncs = (a . map flipTransition) xs
-          a = map (encode . fullListm) . addMissingSignals
-          flipTransition x = (fst x, (invert . snd) x)
-          invert = liftM2 Transition signal (not . newValue)
-          activeTransitions = (map snd .  addMissingSignals) xs
+  where
+    createArc senc tenc xTrans = FsmArcX senc xTrans tenc
+    makeDestEncs = a xs
+    makeSrcEncs = (a . map flipTransition) xs
+    a = map (encode . fullListm) . addMissingSignals
+    flipTransition x = (fst x, (invert . snd) x)
+    invert = liftM2 Transition signal (not . newValue)
+    activeTransitions = (map snd .  addMissingSignals) xs
 
-getInvariantStates :: Ord a => Invariant (Transition a) -> [a] -> [[Tristate]]
-getInvariantStates (NeverAll es) allSigns = expand (encode newTransitions)
-    where newTransitions = transX ++
-                           (concatMap
-                           (map (\s ->
-                           TransitionX { msignal = s, mnewValue = triX }))
-                           missingSigns)
-          transX = map toTransitionX es
-          missingSigns = map (allSigns \\) (onlySignals [es]) -- TODO: Optimise
-          expand t = case elemIndex triX t of
-               Nothing -> [t]
-               Just n  -> do
-                let newTrue = replaceAtIndex triTrue t n
-                let newFalse = replaceAtIndex triFalse t n
-                expand newTrue ++ expand newFalse
+getInvariantStates :: Ord a =>  [a] -> Invariant (Transition a) -> [[Tristate]]
+getInvariantStates allSigns (NeverAll es) = expand (encode newTransitions)
+  where
+    newTransitions = transX ++ (concatMap (map genTransX) missingSigns)
+    genTransX s = TransitionX { msignal = s, mnewValue = triX }
+    transX = map toTransitionX es
+    missingSigns = map (allSigns \\) (onlySignals [es]) -- TODO: Optimise
+    expand t = case elemIndex triX t of
+         Nothing -> [t]
+         Just n  -> do
+           let newTrue = replaceAtIndex triTrue t n
+           let newFalse = replaceAtIndex triFalse t n
+           expand newTrue ++ expand newFalse
 
 replaceAtIndex :: a -> [a] -> Int -> [a]
 replaceAtIndex item ls n = a ++ (item:b)
-    where (a, (_:b)) = splitAt n ls
+  where (a, (_:b)) = splitAt n ls
 
 expandX :: FsmArcX a -> [FsmArcX a]
 expandX xs = case elemIndex triX (srcEncx xs) of
-               Nothing -> [xs]
-               Just n  -> do
-                let newTrue = makeArc (replaceAtIndex triTrue (srcEncx xs) n)
-                                       (replaceAtIndex triTrue (destEncx xs) n)
-                let newFalse = makeArc (replaceAtIndex triFalse (srcEncx xs) n)
-                                  (replaceAtIndex triFalse (destEncx xs) n)
-                expandX newTrue ++ expandX newFalse
-                  where makeArc s d = FsmArcX s (transx xs) d
+    Nothing -> [xs]
+    Just n  -> do
+      let newTrue = makeArc (replaceAtIndex triTrue (srcEncx xs) n)
+                    (replaceAtIndex triTrue (destEncx xs) n)
+      let newFalse = makeArc (replaceAtIndex triFalse (srcEncx xs) n)
+                     (replaceAtIndex triFalse (destEncx xs) n)
+      expandX newTrue ++ expandX newFalse
+        where
+          makeArc s d = FsmArcX s (transx xs) d
 
 expandAllXs :: [FsmArcX a] -> [FsmArcX a]
 expandAllXs = concatMap expandX
@@ -281,14 +281,15 @@ encToInt enc = fromMaybe 0 ((readBin . concatMap show . reverse) enc)
 
 fsmarcxToFsmarc :: FsmArcX a -> FsmArc a
 fsmarcxToFsmarc arc = FsmArc newSourceEnc (transx arc) newDestEnc
-    where newSourceEnc = (encToInt . srcEncx) arc
-          newDestEnc = (encToInt . destEncx) arc
+  where
+    newSourceEnc = (encToInt . srcEncx) arc
+    newDestEnc   = (encToInt . destEncx) arc
 
 removeUnreachables :: [FsmArc a] -> [Int] -> [FsmArc a]
-removeUnreachables xs reachables = filter (\s ->
-                                   (destEnc s `elem` reachables &&
-                                    srcEnc s `elem` reachables))
-                                   xs
+removeUnreachables xs reachables = filter (\s -> checkDest s && checkSrc s) xs
+  where
+    checkDest s = destEnc s `elem` reachables
+    checkSrc s  = srcEnc s `elem` reachables
 
 -- Produce all arcs with all X's resolved
 createAllArcs :: Ord a => [([Transition a], Transition a)] -> [FsmArc a]
@@ -301,8 +302,8 @@ visit :: Ord a => Int -> [FsmArc a] -> Set.Set Int -> [Int]
 visit state allArcs visited = [state] ++ concatMap
                                          (\s -> visit s allArcs newVisited)
                                          (Set.difference destStates visited)
-    where
-      arcSet = Set.fromList allArcs
-      srcStates = Set.filter (\s -> (srcEnc s) == state) arcSet
-      destStates = Set.map destEnc srcStates
-      newVisited = Set.unions [Set.singleton state, visited, destStates]
+  where
+    arcSet = Set.fromList allArcs
+    srcStates = Set.filter (\s -> (srcEnc s) == state) arcSet
+    destStates = Set.map destEnc srcStates
+    newVisited = Set.unions [Set.singleton state, visited, destStates]

--- a/src/Tuura/Concept/FSM/Translation.hs
+++ b/src/Tuura/Concept/FSM/Translation.hs
@@ -81,7 +81,8 @@ instance Show a => Show (FsmArc a) where
 translateFSM :: (Show a, Ord a) => String -> String -> [a] -> GHC.Interpreter()
 translateFSM circuitName ctype signs = do
     circ <- GHC.unsafeInterpret circuitName ctype
-    apply <- GHC.unsafeInterpret "apply" $ "(" ++ ctype ++ ") -> CircuitConcept Signal"
+    apply <- GHC.unsafeInterpret "apply" $ "(" ++ ctype
+             ++ ") -> CircuitConcept Signal"
     let circuit = apply circ
     GHC.liftIO $ putStr (translate circuit signs)
 

--- a/src/Tuura/Concept/FSM/Translation.hs
+++ b/src/Tuura/Concept/FSM/Translation.hs
@@ -115,7 +115,7 @@ fromBool :: Bool -> Tristate
 fromBool x = if x then triTrue else triFalse
 
 addConsistency :: Ord a => [Causality (Transition a)] -> [a] -> [Causality (Transition a)]
-addConsistency allArcs signs = nubOrd (allArcs ++ concatMap (\s -> [AndCausality (rise s) (fall s), AndCausality (fall s) (rise s)]) signs)
+addConsistency allArcs signs = nubOrd (allArcs ++ concatMap (\s -> [Causality [rise s] (fall s), Causality [fall s] (rise s)]) signs)
 
 handleArcs :: NonEmpty ([Transition a], Transition a) -> [([Transition a], Transition a)]
 handleArcs xs = map (\m -> (m, effect)) transCauses

--- a/src/Tuura/Concept/FSM/Translation.hs
+++ b/src/Tuura/Concept/FSM/Translation.hs
@@ -133,7 +133,7 @@ addConsistency allArcs signs = nubOrd (allArcs ++ concatMap (\s ->
                                 Causality [fall s] (rise s)])
                                signs)
 
-handleArcs :: NonEmpty ([Transition a], Transition a) ->
+handleArcs :: Ord a => NonEmpty ([Transition a], Transition a) ->
               [([Transition a], Transition a)]
 handleArcs xs = map (\m -> (m, effect)) transCauses
         where

--- a/src/Tuura/Concept/FSM/Translation.hs
+++ b/src/Tuura/Concept/FSM/Translation.hs
@@ -168,13 +168,12 @@ genFSM inputSigns outputSigns internalSigns arcStrs initState reachReport =
       ins = map show inputSigns
       ints = map show internalSigns
 
-genReachReport :: (Eq a, Show a) => [a] -> String
-genReachReport es
-        | es == []  = "\ninvariant = reachability\n"
-        | otherwise = "\nWarning:\n" ++
-                      "The following state(s) hold for the invariant " ++
-                      "but are not reachable:\n" ++
-                      unlines (unreachStates)
+genReachReport :: (Show a) => [a] -> String
+genReachReport [] = "\ninvariant = reachability\n"
+genReachReport es = "\nWarning:\n" ++
+                    "The following state(s) hold for the invariant " ++
+                    "but are not reachable:\n" ++
+                    unlines (unreachStates)
     where
       unreachStates = [ "s" ++ show e | e <- es ]
 

--- a/src/Tuura/Concept/STG/Translation.hs
+++ b/src/Tuura/Concept/STG/Translation.hs
@@ -24,62 +24,67 @@ translate :: (Show a, Ord a) => CircuitConcept a -> [a] -> String
 translate circuit signs =
     case validate signs circuit of
         Valid -> do
-            let initStrs = map (\s ->
-                    (show s, (getDefined $ initial circuit s))) signs
+            let initStrs = map (\s -> (show s, (getDefined $ getInit s))) signs
                 allArcs = arcLists (arcs circuit)
-                arcStrs = nubOrd (concatMap handleArcs
-                            (groupAllWith snd allArcs))
+                groupByEffect = groupAllWith snd allArcs
+                arcStrs = nubOrd (concatMap handleArcs groupByEffect)
                 invStr = map genInvStrs (invariant circuit)
                 inputSigns = filter ((==Input) . interface circuit) signs
                 outputSigns = filter ((==Output) . interface circuit) signs
                 internalSigns = filter ((==Internal) . interface circuit) signs
             genSTG inputSigns outputSigns internalSigns arcStrs initStrs invStr
         Invalid errs -> addErrors errs
+  where
+    getInit = initial circuit
 
 -- Due to the caller, xs will never be empty, so `snd (head xs)` never fails.
 handleArcs :: (Ord a, Show a) => NonEmpty ([Transition a], Transition a) -> [String]
 handleArcs xs = addConsistencyTrans effect n ++ concatMap transition arcMap
-        where
-            effect = snd (NonEmpty.head xs)
-            effectCauses = NonEmpty.map fst xs
-            transCauses = cartesianProduct effectCauses
-            n = length transCauses
-            arcMap = concat (map (\m -> arcPairs m effect)
-                                (zip transCauses [0..(n-1)]))
+  where
+    effect = snd (NonEmpty.head xs)
+    effectCauses = NonEmpty.map fst xs
+    transCauses = cartesianProduct effectCauses
+    n = length transCauses
+    arcMap = concatMap (\m -> arcPairs m effect) zipCauseNos
+    zipCauseNos = zip transCauses [0..(n - 1)]
 
 genSTG :: Show a => [a] -> [a] -> [a] -> [String] -> [(String, Bool)]
             -> [String] -> String
 genSTG inputSigns outputSigns internalSigns arcStrs initStrs invStr =
-    printf tmpl (unwords ins) (unwords outs) (unwords ints) (unlines allArcs)
-                (unwords marks) (unlines invStr)
-    where
-        allSigns = output initStrs
-        outs = map show outputSigns
-        ins = map show inputSigns
-        ints = map show internalSigns
-        allArcs = concatMap consistencyLoop allSigns ++ arcStrs
-        marks = initVals allSigns initStrs
+    printf tmpl (unwords ins)
+                (unwords outs)
+                (unwords ints)
+                (unlines allArcs)
+                (unwords marks)
+                (unlines invStr)
+  where
+    allSigns = output initStrs
+    outs = map show outputSigns
+    ins = map show inputSigns
+    ints = map show internalSigns
+    allArcs = concatMap consistencyLoop allSigns ++ arcStrs
+    marks = initVals allSigns initStrs
 
 addConsistencyTrans :: Show a => Transition a -> Int -> [String]
 addConsistencyTrans effect n
-        | newValue effect = map (\x ->
-          (printf "%s0 %s/%s\n" (init (show effect)) (show effect) (show x)) ++
-          (printf "%s/%s %s1" (show effect) (show x) (init (show effect))))
-          [1..n - 1]
-        | otherwise = map (\x ->
-          (printf "%s1 %s/%s\n" (init (show effect)) (show effect) (show x)) ++
-          (printf "%s/%s %s0" (show effect) (show x) (init (show effect))))
-          [1..n - 1]
+    | newValue effect = map (\x ->
+      (printf "%s0 %s/%s\n" (init (show effect)) (show effect) (show x)) ++
+      (printf "%s/%s %s1" (show effect) (show x) (init (show effect))))
+      [1..n - 1]
+    | otherwise = map (\x ->
+      (printf "%s1 %s/%s\n" (init (show effect)) (show effect) (show x)) ++
+      (printf "%s/%s %s0" (show effect) (show x) (init (show effect))))
+      [1..n - 1]
 
 arcPairs :: Show a => ([a], Int) -> a -> [(a, String)]
 arcPairs (causes, n) effect
-        | n == 0 = map (\c -> (c, show effect)) causes
-        | otherwise = map (\d -> (d, (show effect  ++ "/" ++ show n))) causes
+    | n == 0 = map (\c -> (c, show effect)) causes
+    | otherwise = map (\d -> (d, (show effect  ++ "/" ++ show n))) causes
 
 transition :: Show a => (Transition a, String) -> [String]
 transition (f, t)
-        | newValue f = readArc (init (show f) ++ "1") t
-        | otherwise  = readArc (init (show f) ++ "0") t
+    | newValue f = readArc (init (show f) ++ "1") t
+    | otherwise  = readArc (init (show f) ++ "0") t
 
 tmpl :: String
 tmpl = unlines [".model out",
@@ -102,10 +107,11 @@ initVals :: [String] -> [(String, Bool)] -> [String]
 initVals l symbs = concat (map (\s -> [printf "%s%i" s $ initVal s symbs]) l)
 
 initVal :: String -> [(String, Bool)] -> Int
-initVal s ls = sum (map (\x -> if (fst x == s)
-                               then fromEnum (snd x)
-                               else 0)
-                   ls)
+initVal s ls = sum (map getValue ls)
+  where
+    getValue x = if (fst x == s)
+                 then fromEnum (snd x)
+                 else 0
 
 readArc :: String -> String -> [String]
 readArc f t = [f ++ " " ++ t, t ++ " " ++ f]
@@ -116,7 +122,7 @@ genInvStrs (NeverAll es)
         | otherwise = "invariant = not (" ++
                       (intercalate " && " (map format es)) ++
                       ")"
-    where
-        format e = if (newValue e)
-                   then show (signal e)
-                   else "not " ++ show (signal e)
+  where
+    format e = if (newValue e)
+               then show (signal e)
+               else "not " ++ show (signal e)

--- a/src/Tuura/Concept/STG/Translation.hs
+++ b/src/Tuura/Concept/STG/Translation.hs
@@ -37,7 +37,7 @@ translate circuit signs =
         Invalid errs -> addErrors errs
 
 -- Due to the caller, xs will never be empty, so `snd (head xs)` never fails.
-handleArcs :: Show a => NonEmpty ([Transition a], Transition a) -> [String]
+handleArcs :: (Ord a, Show a) => NonEmpty ([Transition a], Transition a) -> [String]
 handleArcs xs = addConsistencyTrans effect n ++ concatMap transition arcMap
         where
             effect = snd (NonEmpty.head xs)
@@ -51,7 +51,7 @@ genSTG :: Show a => [a] -> [a] -> [a] -> [String] -> [(String, Bool)]
             -> [String] -> String
 genSTG inputSigns outputSigns internalSigns arcStrs initStrs invStr =
     printf tmpl (unwords ins) (unwords outs) (unwords ints) (unlines allArcs)
-                                             (unwords marks) (unlines invStr)
+                (unwords marks) (unlines invStr)
     where
         allSigns = output initStrs
         outs = map show outputSigns
@@ -105,7 +105,7 @@ initVal :: String -> [(String, Bool)] -> Int
 initVal s ls = sum (map (\x -> if (fst x == s)
                                then fromEnum (snd x)
                                else 0)
-                    ls)
+                   ls)
 
 readArc :: String -> String -> [String]
 readArc f t = [f ++ " " ++ t, t ++ " " ++ f]

--- a/src/Tuura/Concept/Simulation.hs
+++ b/src/Tuura/Concept/Simulation.hs
@@ -23,7 +23,8 @@ allTransitions :: (Enum a, Bounded a) => [Transition a]
 allTransitions =
     [Transition a b | a <- [minBound .. maxBound], b <- [False, True]]
 
-enabledTransitions :: (Enum a, Bounded a, Monad m) => CircuitConcept a -> Simulation a m [Transition a]
+enabledTransitions :: (Enum a, Bounded a, Monad m) => CircuitConcept a ->
+                      Simulation a m [Transition a]
 enabledTransitions c = do
     s <- get
     return $ filter (\t -> excited c t s) allTransitions

--- a/src/Tuura/Concept/Simulation.hs
+++ b/src/Tuura/Concept/Simulation.hs
@@ -23,8 +23,8 @@ allTransitions :: (Enum a, Bounded a) => [Transition a]
 allTransitions =
     [Transition a b | a <- [minBound .. maxBound], b <- [False, True]]
 
-enabledTransitions :: (Enum a, Bounded a, Monad m) => CircuitConcept a ->
-                      Simulation a m [Transition a]
+enabledTransitions :: (Enum a, Bounded a, Monad m) => CircuitConcept a
+                      -> Simulation a m [Transition a]
 enabledTransitions c = do
     s <- get
     return $ filter (\t -> excited c t s) allTransitions

--- a/src/Tuura/Plato/Options.hs
+++ b/src/Tuura/Plato/Options.hs
@@ -19,7 +19,8 @@ defaultOptions   = Options
 options :: [OptDescr (Options -> Options)]
 options =
  [ Option ['i'] ["include"]
-     (ReqArg (\ d opts -> opts { optInclude = optInclude opts ++ [d] }) "FILEPATH")
+     (ReqArg (\ d opts -> opts { optInclude = optInclude opts ++ [d] })
+      "FILEPATH")
      "Concept file to be included"
  , Option ['f'] ["fsm"]
      (NoArg (\ opts -> opts { optFSM = True }))
@@ -33,10 +34,14 @@ getOptions :: IO Options
 getOptions = do
    argv <- getArgs
    result <- case getOpt Permute options argv of
-      (_, [] , _   ) -> ioError (userError ("\nNo input file given\n" ++ helpMessage))
-      (o, [n], []  ) -> return (foldl (flip id) defaultOptions {optInput = n} o)
-      (_, _  , []  ) -> ioError (userError ("\nToo many input files\n" ++ helpMessage))
-      (_, _  , errs) -> ioError (userError (concat errs ++ helpMessage))
+      (_, [] , _   ) -> ioError (userError
+                        ("\nNo input file given\n" ++ helpMessage))
+      (o, [n], []  ) -> return (foldl (flip id)
+                        defaultOptions {optInput = n} o)
+      (_, _  , []  ) -> ioError (userError
+                        ("\nToo many input files\n" ++ helpMessage))
+      (_, _  , errs) -> ioError (userError
+                        (concat errs ++ helpMessage))
    return result
     where
       helpMessage = usageInfo header options

--- a/src/Tuura/Plato/Translation.hs
+++ b/src/Tuura/Plato/Translation.hs
@@ -82,23 +82,20 @@ validateInterface signs circuit
     unused       = filter ((==Unused) . interface circuit) signs
 
 cartesianProduct :: Ord a => NonEmpty.NonEmpty [a] -> [[a]]
-cartesianProduct l = removeSupersets sortByLength
+cartesianProduct l = removeSupersets sortAllLists
   where
     sequenced    = sequence (NonEmpty.toList l)
     removeDupes  = map nub sequenced
     removeNull   = filter (not . null) removeDupes
     sortAllLists = map sort removeNull
-    sortByLength = sortBy (comparing length) sortAllLists
 
 removeSupersets :: Eq a => [[a]] -> [[a]]
 removeSupersets s = filter (not . null) result
   where
     prev n        = take n s
     check current = any (`isSubsequenceOf` current)
-    result        = map (\x -> if check (s!!x) (prev x)
-                        then []
-                        else s!!x
-                 )[0..(length s) - 1]
+    result        = [ x | (x:xs) <- tails sortByLength, not (check x xs) ]
+    sortByLength  = sortBy (comparing $ negate . length) s
 
 arcLists :: [Causality (Transition a)] -> [([Transition a], Transition a)]
 arcLists xs = [ (f, t) | Causality f t <- xs ]

--- a/src/Tuura/Plato/Translation.hs
+++ b/src/Tuura/Plato/Translation.hs
@@ -39,8 +39,8 @@ instance Ord Signal
 addErrors :: (Eq a, Show a) => [ValidationError a] -> String
 addErrors errs = "Error\n" ++
         (if unused /= []
-        then "The following signals are not declared as input, output or internal: \n"
-             ++ unlines (map show unused) ++ "\n"
+        then "The following signals are not declared as input, "
+             ++ "output or internal: \n" ++ unlines (map show unused) ++ "\n"
         else "") ++
         (if incons /= []
         then "The following signals have inconsistent inital states: \n"
@@ -51,8 +51,9 @@ addErrors errs = "Error\n" ++
              ++ unlines (map show undefd) ++ "\n"
         else "") ++
         (if invVio /= []
-        then "The following state(s) are reachable but the invariant does not hold for them:\n"
-             ++ unlines (map show invVio) ++ "\n"
+        then "The following state(s) are reachable " ++
+             "but the invariant does not hold for them:\n" ++
+             unlines (map show invVio) ++ "\n"
         else "")
     where
         unused = [ a | UnusedSignal a             <- errs ]
@@ -61,12 +62,14 @@ addErrors errs = "Error\n" ++
         invVio = [ a | InvariantViolated a        <- errs ]
 
 validate :: Ord a => [a] -> CircuitConcept a -> ValidationResult a
-validate signs circuit = (validateInitialState signs circuit) <> (validateInterface signs circuit)
+validate signs circuit = (validateInitialState signs circuit)
+                      <> (validateInterface signs circuit)
 
 validateInitialState :: Ord a => [a] -> CircuitConcept a -> ValidationResult a
 validateInitialState signs circuit
     | undef ++ inconsistent == [] = Valid
-    | otherwise = Invalid (map UndefinedInitialState undef ++ map InconsistentInitialState inconsistent)
+    | otherwise = Invalid (map UndefinedInitialState undef
+                        ++ map InconsistentInitialState inconsistent)
   where
     undef        = filter ((==Undefined) . initial circuit) signs
     inconsistent = filter ((==Inconsistent) . initial circuit) signs

--- a/src/Tuura/Plato/Translation.hs
+++ b/src/Tuura/Plato/Translation.hs
@@ -90,18 +90,12 @@ cartesianProduct l = removeSupersets sortByLength
 removeSupersets :: Eq a => [[a]] -> [[a]]
 removeSupersets s = filter (not . null) result
   where
-    prev n  = take n s
-    check x = checkForSupersets (s!!x) (prev x)
-    result  = map (\x -> if check x
+    prev n        = take n s
+    check current = any (`isSubsequenceOf` current)
+    result        = map (\x -> if check (s!!x) (prev x)
                         then []
                         else s!!x
                  )[0..(length s) - 1]
-
-checkForSupersets :: Eq a => [a] -> [[a]] -> Bool
-checkForSupersets current previous = any (`elem` subs) previous
-  where
-    subs = subsequences current
-
 
 arcLists :: [Causality (Transition a)] -> [([Transition a], Transition a)]
 arcLists xs = [ (f, t) | Causality f t <- xs ]

--- a/src/Tuura/Plato/Translation.hs
+++ b/src/Tuura/Plato/Translation.hs
@@ -86,15 +86,12 @@ cartesianProduct l = removeSupersets sortAllLists
   where
     sequenced    = sequence (NonEmpty.toList l)
     removeDupes  = map nub sequenced
-    removeNull   = filter (not . null) removeDupes
-    sortAllLists = map sort removeNull
+    sortAllLists = map sort removeDupes
 
 removeSupersets :: Eq a => [[a]] -> [[a]]
-removeSupersets s = filter (not . null) result
+removeSupersets s = [ x | (x:xs) <- tails sortByLength, not (check x xs) ]
   where
-    prev n        = take n s
     check current = any (`isSubsequenceOf` current)
-    result        = [ x | (x:xs) <- tails sortByLength, not (check x xs) ]
     sortByLength  = sortBy (comparing $ negate . length) s
 
 arcLists :: [Causality (Transition a)] -> [([Transition a], Transition a)]

--- a/src/Tuura/Plato/Translation.hs
+++ b/src/Tuura/Plato/Translation.hs
@@ -80,4 +80,4 @@ cartesianProduct :: NonEmpty.NonEmpty [a] -> [[a]]
 cartesianProduct l = sequence (NonEmpty.toList l)
 
 arcLists :: [Causality (Transition a)] -> [([Transition a], Transition a)]
-arcLists xs = [ ([f], t) | AndCausality f t <- xs ] ++ [ (f, t) | OrCausality f t <- xs ]
+arcLists xs = [ (f, t) | Causality f t <- xs ]

--- a/translate/Main.hs
+++ b/translate/Main.hs
@@ -58,7 +58,7 @@ signalsApply num = [
     "import Data.Char",
     "data Signal = Signal Int deriving Eq",
     "signs = [Signal i | i <- [0.." ++ show (num-1) ++ "]]",
-    "apply c = c " ++ unwords ["(signs !! " ++ show i ++ ")" | i <- [0..num-1]]]
+    "apply c = c " ++ unwords ["(signs !! " ++ show i ++")" | i <- [0..num-1]]]
 
 writeTmpFile :: [String] -> IO ()
 writeTmpFile ls =
@@ -89,7 +89,8 @@ loadModulesTopLevel paths = do
     mods <- GHC.getLoadedModules
     GHC.setTopLevelModules mods
 
-doWork :: Bool -> [String] -> GHC.Interpreter () {- TODO: much of this is duplicated -}
+{- TODO: much of this is duplicated -}
+doWork :: Bool -> [String] -> GHC.Interpreter ()
 doWork transFSM paths = do
     {- Load user's module to gather info. -}
     loadModulesTopLevel paths


### PR DESCRIPTION
All causality is now stated as `Causality [e] e` instead of being split into `AndCasuality` and `OrCasuality`. 

AND-causality will contain single element lists as the cause transitions, e.g: 
`rise a ~> rise c <> rise b ~> rise c` 
will be `Causality [a+] c+` and `Causality [b+] c+`

OR-causality will utilise this list format as previously, e.g.:
`[rise a, rise b] ~|~> rise c`
will be `Causality [a+, b+] c+`

Testing has proved this continues to work correctly. 