### PR TITLE
Implemented bubble function to invert a chosen signal's transitions

### DIFF
--- a/src/Tuura/Concept/Circuit/Derived.hs
+++ b/src/Tuura/Concept/Circuit/Derived.hs
@@ -88,18 +88,22 @@ bubble :: Eq a => a -> CircuitConcept a -> CircuitConcept a
 bubble s c = mempty
              {
                 initial = initial c,
-                arcs = map (bubbleBySignal s) (arcs c),
+                arcs = fmap (bubbleCausality s) (arcs c),
                 interface = interface c,
-                invariant = invariant c
+                invariant = fmap (bubbleInvariant s) (invariant c)
              }
-  where
 
-bubbleBySignal :: Eq a => a -> Causality (Transition a) -> Causality (Transition a)
-bubbleBySignal s (Causality f t)
+bubbleCausality :: Eq a => a -> Causality (Transition a) -> Causality (Transition a)
+bubbleCausality s (Causality f t)
     | signal t == s = Causality f (toggle t)
     | otherwise     = Causality (map invertCauses f) t
   where
     invertCauses c = if (signal c == s) then toggle c else c
+
+bubbleInvariant :: Eq a => a -> Invariant (Transition a) -> Invariant (Transition a)
+bubbleInvariant s (NeverAll es) = NeverAll (map invertInvars es)
+  where
+    invertInvars i = if (signal i == s) then toggle i else i
 
 consistency :: CircuitConcept a
 consistency = mempty

--- a/src/Tuura/Concept/Circuit/Derived.hs
+++ b/src/Tuura/Concept/Circuit/Derived.hs
@@ -92,8 +92,8 @@ bubbleInitialValue s f y = if (y == s) then bubbleVal (f y) else f y
     bubbleVal x = x
 
 -- Perform the inversion for just transitions of the given signal
-invertSignal :: Eq a => a -> Transition a -> Transition a
-invertSignal a t
+toggleSpecific :: Eq a => a -> Transition a -> Transition a
+toggleSpecific a t
     | signal t == a = toggle t
     | otherwise     = t
 
@@ -101,13 +101,13 @@ invertSignal a t
 bubbleCausality :: Eq a => a -> Causality (Transition a)
                         -> Causality (Transition a)
 bubbleCausality s (Causality f t)
-    | signal t == s = Causality (map (invertSignal s) f) (toggle t)
-    | otherwise     = Causality (map (invertSignal s) f) t
+    | signal t == s = Causality (map (toggleSpecific s) f) (toggle t)
+    | otherwise     = Causality (map (toggleSpecific s) f) t
 
 -- Invert the invariant transition of the selected signal.
 bubbleInvariant :: Eq a => a -> Invariant (Transition a)
                         -> Invariant (Transition a)
-bubbleInvariant s (NeverAll es) = NeverAll (map (invertSignal s) es)
+bubbleInvariant s (NeverAll es) = NeverAll (map (toggleSpecific s) es)
 
 bubble :: Eq a => a -> CircuitConcept a -> CircuitConcept a
 bubble s c = mempty


### PR DESCRIPTION
`bubble` is a concept transformation function which takes a signal and a concept and `toggle`s all of the transitions for that signal, be they cause/effect transitions in a causality, in AND/OR causalities, for the given concept. This acts as a negation on the chosen signal, be it an input or output.

This serves well to provide inverting gates, for example:
```haskell
bubble c (andGate a b c)
bubble a (orGate a b c)
bubble c (cElement a b c)
```
These will produce a NAND gate, an OR gate with one inverted input (`a`), and an inverting output C-element, respectively. 

This can also be used in combination, for multiple inversions, e.g:
```haskell
bubble b (bubble c (andGate a b c))
```
This will produce a NAND gate with one input (`b`) inverted.