### PR TITLE
Added XOR gate and function to remove redundant combinations of cause transitions

### DIFF
--- a/src/Tuura/Concept/Circuit/Derived.hs
+++ b/src/Tuura/Concept/Circuit/Derived.hs
@@ -6,7 +6,7 @@ module Tuura.Concept.Circuit.Derived (
     initialise0, initialise1,
     (~>), (~|~>),
     buffer, inverter, cElement, meElement,
-    andGate, orGate, me, never, handshake,
+    andGate, orGate, xorGate, me, never, handshake,
     handshake00, handshake11, inputs,
     outputs, internals
     ) where
@@ -160,6 +160,10 @@ andGate a b c = rise a ~> rise c <> rise b ~> rise c
 orGate :: a -> a -> a -> CircuitConcept a
 orGate a b c = [rise a, rise b] ~|~> rise c
             <> fall a ~> fall c <> fall b ~> fall c
+
+xorGate :: a -> a -> a -> CircuitConcept a
+xorGate a b c = [rise a, rise b] ~|~> rise c <> [fall a, fall b] ~|~> rise c
+             <> [rise a, fall b] ~|~> fall c <> [fall a, rise b] ~|~> fall c
 
 -- Protocol-level concepts
 handshake :: a -> a -> CircuitConcept a

--- a/src/Tuura/Plato/Translation.hs
+++ b/src/Tuura/Plato/Translation.hs
@@ -90,12 +90,10 @@ validateInterface signs circuit
 -- Perform cartesian product on list of lists. This will also sort and remove
 -- duplicates in sublists, and remove supersets for the most compact form.
 cartesianProduct :: Ord a => NonEmpty.NonEmpty [Transition a] -> [[Transition a]]
-cartesianProduct l = removeSupersets sortAllLists
+cartesianProduct l = removeSupersets $ removeRedundancies $ 
+                       map (sort . nub) sequenced
   where
     sequenced    = sequence (NonEmpty.toList l)
-    removeDupes  = map nub sequenced
-    removeRedun  = removeRedundancies removeDupes
-    sortAllLists = map sort removeRedun
 
 -- Sort list of lists from largest length to shortest, then remove any lists
 -- that have shorter subsequences within the rest of the list.
@@ -106,9 +104,7 @@ removeSupersets s = [ x | (x:xs) <- tails sortByLength, not (check x xs) ]
     sortByLength  = sortBy (comparing $ negate . length) s
 
 removeRedundancies :: Eq a => [[Transition a]] -> [[Transition a]]
-removeRedundancies s = filter (\ts -> 
-                         all (\t -> not ((toggle t) `elem` ts)) ts
-                       ) s
+removeRedundancies = filter (\ts -> all (\t -> not ((toggle t) `elem` ts)) ts)
 
 --Create a tuple containing a list of possible causes, for each effect.
 arcLists :: [Causality (Transition a)] -> [([Transition a], Transition a)]

--- a/src/Tuura/Plato/Translation.hs
+++ b/src/Tuura/Plato/Translation.hs
@@ -89,20 +89,26 @@ validateInterface signs circuit
 
 -- Perform cartesian product on list of lists. This will also sort and remove
 -- duplicates in sublists, and remove supersets for the most compact form.
-cartesianProduct :: Ord a => NonEmpty.NonEmpty [a] -> [[a]]
+cartesianProduct :: Ord a => NonEmpty.NonEmpty [Transition a] -> [[Transition a]]
 cartesianProduct l = removeSupersets sortAllLists
   where
     sequenced    = sequence (NonEmpty.toList l)
     removeDupes  = map nub sequenced
-    sortAllLists = map sort removeDupes
+    removeRedun  = removeRedundancies removeDupes
+    sortAllLists = map sort removeRedun
 
 -- Sort list of lists from largest length to shortest, then remove any lists
 -- that have shorter subsequences within the rest of the list.
-removeSupersets :: Eq a => [[a]] -> [[a]]
+removeSupersets :: Eq a => [[Transition a]] -> [[Transition a]]
 removeSupersets s = [ x | (x:xs) <- tails sortByLength, not (check x xs) ]
   where
     check current = any (`isSubsequenceOf` current)
     sortByLength  = sortBy (comparing $ negate . length) s
+
+removeRedundancies :: Eq a => [[Transition a]] -> [[Transition a]]
+removeRedundancies s = filter (\ts -> 
+                         all (\t -> not ((toggle t) `elem` ts)) ts
+                       ) s
 
 --Create a tuple containing a list of possible causes, for each effect.
 arcLists :: [Causality (Transition a)] -> [([Transition a], Transition a)]


### PR DESCRIPTION
Redundancy removal been tested with the XOR gate in question, a 3 input XOR, and some older examples, such as an AO22, to ensure this has not affected the existing working.