### PR TITLE
Added generalised multi-input gates.

### DIFF
--- a/src/Tuura/Concept/Circuit/Derived.hs
+++ b/src/Tuura/Concept/Circuit/Derived.hs
@@ -7,7 +7,7 @@ module Tuura.Concept.Circuit.Derived (
     initialise0, initialise1,
     (~>), (~|~>), (~&~>),
     buffer, inverter, cElement, meElement,
-    andGate, orGate, xorGate, srLatch,
+    andGate, orGate, xorGate, srLatch, srLatch2,
     mutex, never, handshake,
     handshake00, handshake11,
     cElementN, orGateN, andGateN,
@@ -172,7 +172,10 @@ xorGate i1 i2 o = [rise i1, rise i2] ~|~> rise o <> [fall i1, fall i2] ~|~> rise
                <> [rise i1, fall i2] ~|~> fall o <> [fall i1, rise i2] ~|~> fall o
 
 srLatch :: Eq a => a -> a -> a -> CircuitConcept a
-srLatch s r q = complexGate ((Var s) `And` (Not (Var r))) ((Var r) `And` (Not (Var s))) q
+srLatch s r q = complexGate (Var s) (Var r) q
+
+srLatch2 :: Eq a => a -> a -> a -> a -> CircuitConcept a
+srLatch2 s r q nq = srLatch s r q <> bubble nq (srLatch s r nq)
 
 -- Protocol-level concepts
 handshake :: a -> a -> CircuitConcept a

--- a/src/Tuura/Concept/Circuit/Derived.hs
+++ b/src/Tuura/Concept/Circuit/Derived.hs
@@ -7,7 +7,7 @@ module Tuura.Concept.Circuit.Derived (
     initialise0, initialise1,
     (~>), (~|~>), (~&~>),
     buffer, inverter, cElement, meElement,
-    andGate, orGate, xorGate, srLatch, srLatch2,
+    andGate, orGate, xorGate,
     mutex, never, handshake,
     handshake00, handshake11,
     cElementN, orGateN, andGateN,
@@ -170,12 +170,6 @@ andGate i1 i2 o = dual $ orGate i1 i2 o
 xorGate :: a -> a -> a -> CircuitConcept a
 xorGate i1 i2 o = [rise i1, rise i2] ~|~> rise o <> [fall i1, fall i2] ~|~> rise o
                <> [rise i1, fall i2] ~|~> fall o <> [fall i1, rise i2] ~|~> fall o
-
-srLatch :: Eq a => a -> a -> a -> CircuitConcept a
-srLatch s r q = complexGate (Var s) (Var r) q <> never [rise s, rise r]
-
-srLatch2 :: Eq a => a -> a -> a -> a -> CircuitConcept a
-srLatch2 s r q nq = srLatch s r q <> bubble nq (srLatch s r nq) <> mutex q nq
 
 -- Protocol-level concepts
 handshake :: a -> a -> CircuitConcept a

--- a/src/Tuura/Concept/Circuit/Derived.hs
+++ b/src/Tuura/Concept/Circuit/Derived.hs
@@ -172,10 +172,10 @@ xorGate i1 i2 o = [rise i1, rise i2] ~|~> rise o <> [fall i1, fall i2] ~|~> rise
                <> [rise i1, fall i2] ~|~> fall o <> [fall i1, rise i2] ~|~> fall o
 
 srLatch :: Eq a => a -> a -> a -> CircuitConcept a
-srLatch s r q = complexGate (Var s) (Var r) q
+srLatch s r q = complexGate (Var s) (Var r) q <> mutex s r
 
 srLatch2 :: Eq a => a -> a -> a -> a -> CircuitConcept a
-srLatch2 s r q nq = srLatch s r q <> bubble nq (srLatch s r nq)
+srLatch2 s r q nq = srLatch s r q <> bubble nq (srLatch s r nq) <> mutex q nq
 
 -- Protocol-level concepts
 handshake :: a -> a -> CircuitConcept a

--- a/src/Tuura/Concept/Circuit/Derived.hs
+++ b/src/Tuura/Concept/Circuit/Derived.hs
@@ -172,7 +172,7 @@ xorGate i1 i2 o = [rise i1, rise i2] ~|~> rise o <> [fall i1, fall i2] ~|~> rise
                <> [rise i1, fall i2] ~|~> fall o <> [fall i1, rise i2] ~|~> fall o
 
 srLatch :: Eq a => a -> a -> a -> CircuitConcept a
-srLatch s r q = complexGate (Var s) (Var r) q <> mutex s r
+srLatch s r q = complexGate (Var s) (Var r) q <> never [rise s, rise r]
 
 srLatch2 :: Eq a => a -> a -> a -> a -> CircuitConcept a
 srLatch2 s r q nq = srLatch s r q <> bubble nq (srLatch s r nq) <> mutex q nq

--- a/src/Tuura/Concept/Circuit/Derived.hs
+++ b/src/Tuura/Concept/Circuit/Derived.hs
@@ -9,6 +9,7 @@ module Tuura.Concept.Circuit.Derived (
     buffer, inverter, cElement, mutexElement,
     andGate, orGate, xorGate, mutex, never, handshake,
     handshake00, handshake11,
+    cElementN, orGateN, andGateN,
     inputs, outputs, internals, function, complexGate
     ) where
 
@@ -184,6 +185,16 @@ mutex a b = fall a ~> rise b <> fall b ~> rise a <> never [rise a, rise b]
 
 never :: [Transition a] -> CircuitConcept a
 never es = invariantConcept (NeverAll es)
+
+-- Generalized multi-input gates
+cElementN :: [a] -> a -> CircuitConcept a
+cElementN ins out = mconcat $ map (`buffer` out) ins
+
+orGateN :: [a] -> a -> CircuitConcept a
+orGateN ins out = map rise ins ~|~> rise out <> map fall ins ~&~> fall out
+
+andGateN :: [a] -> a -> CircuitConcept a
+andGateN ins out = dual $ orGateN ins out
 
 -- Signal type declaration concepts
 inputs :: Eq a => [a] -> CircuitConcept a


### PR DESCRIPTION
`cElementN` for multi-input C-element.
`orGateN` for multi-input OR gate.
`andGateN` for multi-input AND gate.

Also changed some signal names to match with conventions, mainly using `z` for outputs, and so it
matches the thesis.