### PR TITLE
Added US spellings of initialise (initialize)

### DIFF
--- a/src/Tuura/Concept/Circuit/Derived.hs
+++ b/src/Tuura/Concept/Circuit/Derived.hs
@@ -6,6 +6,7 @@ module Tuura.Concept.Circuit.Derived (
     dual, bubble, bubbles, enable, enables, sync,
     consistency, initialise,
     initialise0, initialise1,
+    initialize, initialize1, initialize0,
     (~>), (~|~>), (~&~>),
     buffer, inverter, cElement, meElement,
     andGate, orGate, xorGate, srLatch, srHalfLatch,
@@ -153,6 +154,17 @@ initialise0 as = initialise (head as) False <> initialise0 (tail as)
 initialise1 :: Eq a => [a] -> CircuitConcept a
 initialise1 [] = mempty
 initialise1 as = initialise (head as) True <> initialise1 (tail as)
+
+--Allow US spellings
+--TODO: Find a neater way of including multiple spellings of functions
+initialize :: Eq a => a -> Bool -> CircuitConcept a
+initialize = initialise
+
+initialize0 :: Eq a => [a] -> CircuitConcept a
+initialize0 = initialise0
+
+initialize1 :: Eq a => [a] -> CircuitConcept a
+initialize1 = initialise1
 
 (~>) :: Transition a -> Transition a -> CircuitConcept a
 (~>) = arcConcept


### PR DESCRIPTION
Since the article has had all references to `initialise` changed to `initialize`, it makes sense to set the snap-shot of the repo to a point where `initialize` can be used.

At the moment it is quite a crude method of doing it, but there is not time to find a better method before the article must be completed.